### PR TITLE
Always include crypt.h header for crypt function

### DIFF
--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -21,9 +21,7 @@
 #include <gcrypt.h>
 #endif
 
-#ifdef _WIN32
 #include <crypt.h>
-#endif
 
 
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
（オリジナルのJDもですが）Fedora 28でビルドが通らないのでその修正です。

glibc 2.27 deprecated libcrypt and Fedora 28 now uses
libxcrypt instead. So to use crypt() function, it must always
include crypt.h (glibc 2.26 had the function in unistd.h).