### PR TITLE
Check array member access more strictly

### DIFF
--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -136,7 +136,7 @@ const std::list< std::string > MISC::split_line( const std::string& str )
 
         // " から始まる ( \"は除く )
         dquote = false;
-        if( str[ i ] == '\"' && str[ i -1 ] != '\\' ){
+        if( str[ i ] == '\"' && i >= 1 && str[ i -1 ] != '\\' ){
             dquote = true;
             ++i;
         }
@@ -184,7 +184,7 @@ const std::list< std::string > MISC::StringTokenizer( const std::string& str, co
     for(;;){
 
         while( i2 < lng && str[ i2++ ] != delim );
-        int tmp = ( str[ i2-1 ] == delim || str[ i2 -1 ] == '\n' ) ? 1 : 0;
+        int tmp = ( i2 >= 1 && ( str[ i2-1 ] == delim || str[ i2 -1 ] == '\n' ) ) ? 1 : 0;
         if( i2 - i ) list_str.push_back( str.substr( i, i2 - i - tmp ) );
         if( i2 >= lng ) break;
         i = i2;
@@ -324,7 +324,8 @@ const std::string MISC::remove_space( const std::string& str )
         if( str[ i2 ] == ' ' ) --i2;
 
         // 全角
-        else if( str[ i2 - lng_space +1 ] == str_space[ 0 ] &&
+        else if( i2 +1 >= lng_space &&
+                 str[ i2 - lng_space +1 ] == str_space[ 0 ] &&
                  str[ i2 - lng_space +2 ] == str_space[ 1 ] &&
                  ( lng_space == 2 || str[ i2 - lng_space +3 ] == str_space[ 2 ] ) ) i2 -= lng_space;
         else break;


### PR DESCRIPTION
Fedora rawhideでgcc8でビルドすると、（オリジナルもそうですが）std::stringのアクセスが厳しくなっていて、そのままだと
```
$ ./src/jd

(process:27119): GLib-WARNING **: 23:24:45.256: gmem.c:489: custom memory allocation vtable not supported
/usr/include/c++/8/bits/basic_string.h:1029: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference = const char&; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]: Assertion '__pos <= size()' failed.
中止 (コアダンプ)
```
みたいになって動きません

gcc8 now checks array member access more strictly.