### PR TITLE
Deprecate usage of GLib memory profiler on 2.46 and above

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,6 +481,7 @@ int main( int argc, char **argv )
     }
 #endif
 
+#if ! GLIB_CHECK_VERSION(2, 46, 0)
 #ifdef _DEBUG_MEM_PROFILE
     g_mem_set_vtable( glib_mem_profiler_table );
     atexit( g_mem_profile );
@@ -494,6 +495,7 @@ int main( int argc, char **argv )
     vtable.try_malloc = malloc;
     vtable.try_realloc = realloc;
     g_mem_set_vtable( &vtable );
+#endif
 #endif
 
     Gtk::Main m( &argc, &argv );


### PR DESCRIPTION
http://mao.5ch.net/test/read.cgi/linux/1516535816/354

あたりから議論になっていますが、GLib内部のprofiler機能
https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html#g-mem-set-vtable
https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html#g-mem-profile

は、2.46でdeprecatedになっていて、それ以降のGLibでは、起動時に警告が出るだけで
何もしないので、2.46以降では使用しないようにするためのpatchです。

まだ、CentOS 6 (GLib 2.28)や、Ubuntu LTS 14.04 (GLIb 2.40)では、2.46になってないので、
一応残しました。