### PR TITLE
Replace deprecated features

### DIFF
--- a/src/article/articleviewbase.cpp
+++ b/src/article/articleviewbase.cpp
@@ -190,7 +190,7 @@ void ArticleViewBase::setup_action()
 #endif
 
     // アクショングループを作ってUIマネージャに登録
-    action_group().clear();
+    action_group().reset();
     action_group() = Gtk::ActionGroup::create();
     action_group()->add( Gtk::Action::create( "BookMark", "しおりを設定/解除(_B)"), sigc::mem_fun( *this, &ArticleViewBase::slot_bookmark ) );
     action_group()->add( Gtk::Action::create( "PostedMark", "書き込みマークを設定/解除(_P)"), sigc::mem_fun( *this, &ArticleViewBase::slot_postedmark ) );
@@ -321,7 +321,7 @@ void ArticleViewBase::setup_action()
             sigc::bind< int >( sigc::mem_fun( *this, &ArticleViewBase::slot_usrcmd ), i ) );
     }
 
-    ui_manager().clear();
+    ui_manager().reset();
     ui_manager() = Gtk::UIManager::create();
     ui_manager()->insert_action_group( action_group() );
 

--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1118,13 +1118,13 @@ const bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset
     std::cout << "create backscreen : width = " << m_view.get_width() << " height = " << m_view.get_height() << std::endl;
 #endif
 
-    m_backscreen.clear();
+    m_backscreen.reset();
     m_backscreen = Gdk::Pixmap::create( m_window, m_view.get_width(), m_view.get_height() );
 
     m_rect_backscreen.y = 0;
     m_rect_backscreen.height = 0;
 
-    m_back_frame.clear();
+    m_back_frame.reset();
     m_back_frame = Gdk::Pixmap::create( m_window, m_view.get_width(), WIDTH_FRAME * 2 );
 
     m_ready_back_frame = false;

--- a/src/article/embeddedimage.cpp
+++ b/src/article/embeddedimage.cpp
@@ -144,7 +144,7 @@ void EmbeddedImage::resize_thread()
 
         m_pixbuf = pixbuf->scale_simple( width, height, interptype );
     }
-    m_imgloader.clear();
+    m_imgloader.reset();
 
     // メインスレッドにリサイズが終わったことを知らせて
     // メインスレッドがpthread_join()を呼び出す

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -120,7 +120,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     if( CONFIG::get_abone_transparent() || CONFIG::get_abone_chain() ){
         m_label_abone.set_text( "チェック出来ない場合は設定メニューから「デフォルトで透明/連鎖あぼ〜ん」を解除して下さい" );
-        m_label_abone.set_alignment( Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER );
+        m_label_abone.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
         m_vbox_abone.pack_start( m_label_abone, Gtk::PACK_SHRINK );
     }
 

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -1859,7 +1859,7 @@ void BBSListViewBase::slot_row_exp( const Gtk::TreeModel::iterator&, const Gtk::
 
     // 他のフォルダを全て閉じる
     if( m_open_only_onedir
-        && path.get_depth() == 1  // 子フォルダの時は閉じない
+        && path.size() == 1  // 子フォルダの時は閉じない
         ){
         m_expanding = true;
         m_treeview.collapse_all();

--- a/src/bbslist/selectdialog.cpp
+++ b/src/bbslist/selectdialog.cpp
@@ -48,12 +48,12 @@ SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url,
     Glib::ustring name;
 
     name = "お気に入りの先頭に追加";
-    m_combo_dirs.append_text( name );
+    m_combo_dirs.append( name );
     if( ! active_row && name == SESSION::get_dir_select_favorite() ) active_row = m_vec_path.size();
     m_vec_path.push_back( "-1" );
 
     name = "お気に入りの最後に追加";
-    m_combo_dirs.append_text( name );
+    m_combo_dirs.append( name );
     if( ! active_row && name == SESSION::get_dir_select_favorite() ) active_row = m_vec_path.size();
     m_vec_path.push_back( "" );
 
@@ -67,7 +67,7 @@ SelectListDialog::SelectListDialog( Gtk::Window* parent, const std::string& url,
         if( type == TYPE_DIR ){
 
             name = row[ columns.m_name ];
-            m_combo_dirs.append_text( name );
+            m_combo_dirs.append( name );
             if( ! active_row && name == SESSION::get_dir_select_favorite() ) active_row = m_vec_path.size();
 
             Gtk::TreePath path = m_treestore->get_path( row );

--- a/src/bbslist/toolbar.cpp
+++ b/src/bbslist/toolbar.cpp
@@ -35,7 +35,7 @@ BBSListToolBar::BBSListToolBar() :
 {
     m_button_toggle.get_button()->set_tooltip_arrow( "ページ切り替え\n\nマウスホイール回転でも切り替え可能" );
 
-    m_label.set_alignment( Gtk::ALIGN_LEFT );
+    m_label.set_alignment( Gtk::ALIGN_START );
     std::vector< std::string > menu;
     menu.push_back( ITEM_NAME_BBSLISTVIEW );
     menu.push_back( ITEM_NAME_FAVORITEVIEW );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -673,7 +673,7 @@ void BoardViewBase::update_columns()
                 break;
         }
 
-        Gtk::CellRenderer *cell = column->get_first_cell_renderer();
+        Gtk::CellRenderer *cell = column->get_first_cell();
 
         // 実際の描画の際に cellrendere のプロパティをセットするスロット関数
         if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &BoardViewBase::slot_cell_data ) );

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -295,7 +295,7 @@ void BoardViewBase::setup_action()
     // その他
     action_group()->add( Gtk::Action::create( "Etc_Menu", ITEM_NAME_ETC "(_O)" ) );
 
-    ui_manager().clear();
+    ui_manager().reset();
     ui_manager() = Gtk::UIManager::create();
     ui_manager()->insert_action_group( action_group() );
 

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -47,7 +47,7 @@ namespace CORE
             for(;;){
                 std::string label = CORE::get_browser_label( i++ );
                 if( label.empty() ) break;
-                m_combo.append_text( label );
+                m_combo.append( label );
             }
 
             m_combo.set_active( CONFIG::get_browsercombo_id() );

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -59,7 +59,7 @@ namespace CORE
             m_hbox.add( m_entry_browser );
             m_frame.set_label( "ブラウザ起動コマンド" );
             m_frame.add( m_hbox );
-            m_label_notice.set_alignment( Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER );
+            m_label_notice.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
 
             m_vbox.set_border_width( mrg );
             m_vbox.pack_start( m_label_notice, Gtk::PACK_EXPAND_WIDGET, mrg );

--- a/src/config/aboutconfig.cpp
+++ b/src/config/aboutconfig.cpp
@@ -58,12 +58,12 @@ void AboutConfig::pack_widgets()
     column->set_sizing( Gtk::TREE_VIEW_COLUMN_FIXED );
     column->set_resizable( true );
     m_treeview.append_column( *column );
-    Gtk::CellRenderer *cell = column->get_first_cell_renderer();
+    Gtk::CellRenderer *cell = column->get_first_cell();
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &AboutConfig::slot_cell_data ) );
 
     column = Gtk::manage( new Gtk::TreeViewColumn( "値", m_columns.m_col_value ) );
     m_treeview.append_column( *column );
-    cell = column->get_first_cell_renderer();
+    cell = column->get_first_cell();
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &AboutConfig::slot_cell_data ) );
 
     m_scrollwin.add( m_treeview );

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -529,7 +529,7 @@ MouseKeyPref::MouseKeyPref( Gtk::Window* parent, const std::string& url, const s
     column = Gtk::manage( new Gtk::TreeViewColumn( target, m_columns.m_col_motions ) );
     column->set_resizable( true );
     m_treeview.append_column( *column );
-    Gtk::CellRenderer *cell = column->get_first_cell_renderer();
+    Gtk::CellRenderer *cell = column->get_first_cell();
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &MouseKeyPref::slot_cell_data ) );
 
     m_scrollwin.add( m_treeview );

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -298,7 +298,7 @@ void FontColorPref::set_font_settings( const std::string& name, const int fontid
 {
     if( ! name.empty() && fontid < FONT_NUM )
     {
-        m_combo_font.append_text( name );
+        m_combo_font.append( name );
         m_font_tbl.push_back( fontid );
         m_tooltips_font.push_back( tooltip );
     }

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -202,12 +202,12 @@ void FontColorPref::pack_widget()
     column->set_sizing( Gtk::TREE_VIEW_COLUMN_FIXED );
     column->set_resizable( true );
     m_treeview_color.append_column( *column );
-    Gtk::CellRenderer *cell = column->get_first_cell_renderer();
+    Gtk::CellRenderer *cell = column->get_first_cell();
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &FontColorPref::slot_cell_data_name ) );
 
     column = Gtk::manage( new Gtk::TreeViewColumn( "色", m_columns_color.m_col_color ) );
     m_treeview_color.append_column( *column );
-    cell = column->get_first_cell_renderer();
+    cell = column->get_first_cell();
     if( cell ) column->set_cell_data_func( *cell, sigc::mem_fun( *this, &FontColorPref::slot_cell_data_color ) );
 
     m_bt_change_color.signal_clicked().connect( sigc::mem_fun( *this, &FontColorPref::slot_change_color ) );

--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -227,7 +227,7 @@ void ImageAreaBase::set_image()
             set( m_imgloader->get_animation() );
         }
     }
-    m_imgloader.clear();
+    m_imgloader.reset();
 
     set_ready( true );
 }

--- a/src/image/imageareaicon.cpp
+++ b/src/image/imageareaicon.cpp
@@ -59,11 +59,11 @@ void ImageAreaIcon::show_image()
     if( m_shown && get_img()->is_cached() ) return;
 
     if( m_pixbuf ){
-        m_pixbuf.clear();
-        m_pixbuf_loading.clear();
-        m_pixbuf_err.clear();
+        m_pixbuf.reset();
+        m_pixbuf_loading.reset();
+        m_pixbuf_err.reset();
     }
-    if( m_pixbuf_icon ) m_pixbuf_icon.clear();
+    if( m_pixbuf_icon ) m_pixbuf_icon.reset();
 
     m_shown = false;
     set_ready( false );
@@ -111,7 +111,7 @@ void ImageAreaIcon::load_image_thread()
         if( pixbuf ) 
             m_pixbuf_icon = pixbuf->scale_simple( get_width(), get_height(), Gdk::INTERP_NEAREST );
     }
-    m_imgloader.clear();
+    m_imgloader.reset();
 
     if( m_pixbuf_icon ){
         m_imagetype = IMAGE_SHOW_ICON;

--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -181,7 +181,7 @@ const bool ImgLoader::load_imgfile( const int loadlevel )
 #endif
         if( ! m_stop ){
             m_errmsg = err.what();
-            m_loader.clear();
+            m_loader.reset();
             ret = false;
         }
     }

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -21,8 +21,8 @@ using namespace CORE;
 
 LinkFilterDiag::LinkFilterDiag( Gtk::Window* parent, const std::string& url, const std::string& cmd )
     : SKELETON::PrefDiag( parent, "" ),
-      m_label_url( "アドレス", Gtk::ALIGN_LEFT ),
-      m_label_cmd( "実行するコマンド", Gtk::ALIGN_LEFT ),
+      m_label_url( "アドレス", Gtk::ALIGN_START ),
+      m_label_cmd( "実行するコマンド", Gtk::ALIGN_START ),
       m_button_manual( "オンラインマニュアルの置換文字一覧を表示" )
 {
     resize( 640, 1 );

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -407,8 +407,8 @@ void MessageViewBase::set_mail()
 void MessageViewBase::pack_widget()
 {
     // 書き込みビュー
-    m_label_name.set_alignment( Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER );
-    m_label_mail.set_alignment( Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER );
+    m_label_name.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
+    m_label_mail.set_alignment( Gtk::ALIGN_START, Gtk::ALIGN_CENTER );
     m_label_name.set_text( " 名前 " );
     m_label_mail.set_text( " メール " );
 

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -20,8 +20,8 @@ enum
 };
 
 PageStart::PageStart() : Gtk::VBox(),
-                         m_label( "１/５．JD セットアップ開始", Gtk::ALIGN_LEFT ),
-                         m_label2( "JDセットアップウィザードへようこそ\n\nこのウィザードでネットワークとフォント等の設定をおこないます\n\n設定を始めるには［次へ］を押してください", Gtk::ALIGN_LEFT )
+                         m_label( "１/５．JD セットアップ開始", Gtk::ALIGN_START ),
+                         m_label2( "JDセットアップウィザードへようこそ\n\nこのウィザードでネットワークとフォント等の設定をおこないます\n\n設定を始めるには［次へ］を押してください", Gtk::ALIGN_START )
 {
     m_icon.set( ICON::get_icon_manager()->get_icon( ICON::JD48 ) );
     m_hbox_label.set_spacing( SPACING_SIZE );
@@ -38,11 +38,11 @@ PageStart::PageStart() : Gtk::VBox(),
 
 
 PageNet::PageNet() : Gtk::VBox(),
-                     m_label( "２/５．ネットワークの設定をします", Gtk::ALIGN_LEFT ),
+                     m_label( "２/５．ネットワークの設定をします", Gtk::ALIGN_START ),
                      m_proxy( "プロキシ設定(_P)", true ),
                      m_browser( "ブラウザ設定(_W)", true ),
                      m_frame( "ブラウザ起動コマンド" ),   // フレーム
-                     m_label_browser( CONFIG::get_command_openurl(), Gtk::ALIGN_LEFT )
+                     m_label_browser( CONFIG::get_command_openurl(), Gtk::ALIGN_START )
 {
 
     m_icon.set( ICON::get_icon_manager()->get_icon( ICON::JD48 ) );
@@ -103,11 +103,11 @@ void PageNet::slot_setup_browser()
 
 
 PageFont::PageFont() : Gtk::VBox(),
-                       m_label( "３/５．フォントの設定をします", Gtk::ALIGN_LEFT ),
+                       m_label( "３/５．フォントの設定をします", Gtk::ALIGN_START ),
                        m_table( 2, 3 ),
-                       m_label_res( "スレ(_T)", Gtk::ALIGN_LEFT, Gtk::ALIGN_TOP, true ),
-                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_LEFT, Gtk::ALIGN_TOP, true ),
-                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_LEFT, Gtk::ALIGN_TOP,  true ),
+                       m_label_res( "スレ(_T)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
+                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
+                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_START, Gtk::ALIGN_START,  true ),
                        m_font_res( "スレフォント" ),
                        m_font_popup( "ポップアップフォント" ),
                        m_font_tree( "板／スレ一覧フォント" )
@@ -167,11 +167,11 @@ void PageFont::slot_font_tree()
 
 
 PagePane::PagePane() : Gtk::VBox(),
-                       m_label( "４/５．ペイン表示設定をします", Gtk::ALIGN_LEFT ),
+                       m_label( "４/５．ペイン表示設定をします", Gtk::ALIGN_START ),
                        m_2pane( m_radiogroup, "２ペイン表示(_2)", true ),
                        m_3pane( m_radiogroup, "３ペイン表示(_3)", true ),
                        m_v3pane( m_radiogroup, "縦３ペイン表示(_V)", true ),
-                       m_label_inst( "" , Gtk::ALIGN_LEFT )
+                       m_label_inst( "" , Gtk::ALIGN_START )
 {
     m_icon.set( ICON::get_icon_manager()->get_icon( ICON::JD48 ) );
     m_hbox_label.set_spacing( SPACING_SIZE );
@@ -222,8 +222,8 @@ void PagePane::slot_v3pane()
 
 
 PageEnd::PageEnd() : Gtk::VBox(),
-                     m_label( "５/５．JD セットアップ完了", Gtk::ALIGN_LEFT ),
-                     m_label2( "その他の設定は起動後に設定及び表示メニューからおこなって下さい\n\n完了を押すとJDを起動して板一覧のリストをロードします\n板一覧が表示されるまでしばらくお待ち下さい" , Gtk::ALIGN_LEFT )
+                     m_label( "５/５．JD セットアップ完了", Gtk::ALIGN_START ),
+                     m_label2( "その他の設定は起動後に設定及び表示メニューからおこなって下さい\n\n完了を押すとJDを起動して板一覧のリストをロードします\n板一覧が表示されるまでしばらくお待ち下さい" , Gtk::ALIGN_START )
 {
     m_icon.set( ICON::get_icon_manager()->get_icon( ICON::JD48 ) );
     m_hbox_label.set_spacing( SPACING_SIZE );

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -262,7 +262,7 @@ bool CompletionEntry::slot_entry_focus_out( GdkEventFocus* )
 bool CompletionEntry::slot_treeview_motion( GdkEventMotion* )
 {
     Gtk::TreeModel::Path path = m_treeview.get_path_under_mouse();
-    if( path.get_depth() > 0 ) m_treeview.set_cursor( path );
+    if( path.size() > 0 ) m_treeview.set_cursor( path );
 
     return true;
 }

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -499,7 +499,7 @@ Gtk::TreeViewColumn* EditTreeView::create_column( const int ypad )
     col->set_sizing( Gtk::TREE_VIEW_COLUMN_FIXED );
 
     // 実際の描画時に偶数行に色を塗る
-    col->set_cell_data_func( *col->get_first_cell_renderer(), sigc::mem_fun( *this, &DragTreeView::slot_cell_data ) );
+    col->set_cell_data_func( *col->get_first_cell(), sigc::mem_fun( *this, &DragTreeView::slot_cell_data ) );
     col->set_cell_data_func( *m_ren_text, sigc::mem_fun( *this, &DragTreeView::slot_cell_data ) );
 
     append_column( *col );

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -948,7 +948,7 @@ const bool EditTreeView::is_dir( Gtk::TreeModel::iterator& it )
 
 const bool EditTreeView::is_dir( const Gtk::TreePath& path )
 {
-    if( path.get_depth() <= 0 ) return false;
+    if( path.size() <= 0 ) return false;
     Gtk::TreeModel::iterator it = get_model()->get_iter( path );
     return is_dir( it );
 }
@@ -977,7 +977,7 @@ void EditTreeView::next_dir()
     Gtk::TreePath path = get_current_path();
     for(;;){
         path = next_path( path );
-        if( ! path.get_depth() || ! get_row( path ) ){
+        if( ! path.size() || ! get_row( path ) ){
             goto_bottom();
             return;
         }
@@ -1801,7 +1801,7 @@ void EditTreeView::sort( const Gtk::TreePath& path, const int mode )
     if( ! get_row( path_head ) ) return;
 
     Gtk::TreePath path_parent = path_head;
-    if( path_parent.get_depth() >= 2 ) path_parent.up();
+    if( path_parent.size() >= 2 ) path_parent.up();
     else path_parent = Gtk::TreePath();
 
 #ifdef _DEBUG
@@ -1895,7 +1895,7 @@ EditTreeViewIterator::EditTreeViewIterator( EditTreeView& treeview, EditColumns&
     if( ! row ) m_end = true;
     else{
 
-        m_depth = m_path.get_depth();
+        m_depth = m_path.size();
         if( ! root ) ++m_depth;
     }
 }
@@ -1931,7 +1931,7 @@ void EditTreeViewIterator::operator ++ ()
 
         else{
 
-            if( m_path.get_depth() > m_depth ){
+            if( m_path.size() > m_depth ){
                 m_path.up();
                 m_path.next();
             }

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -270,7 +270,7 @@ namespace SKELETON
     {
         EditTreeView& m_treeview;
         EditColumns& m_columns;
-        int m_depth;
+        Gtk::TreePath::size_type m_depth;
         bool m_end;
 
         Gtk::TreePath m_path;

--- a/src/skeleton/label_entry.cpp
+++ b/src/skeleton/label_entry.cpp
@@ -18,7 +18,7 @@ LabelEntry::LabelEntry( const bool editable, const std::string& label, const std
     pack_start( m_label, Gtk::PACK_SHRINK );
 
     m_info.set_size_request( 0, 0 );
-    m_info.set_alignment( Gtk::ALIGN_LEFT );
+    m_info.set_alignment( Gtk::ALIGN_START );
     m_info.set_selectable( true );
 
     setup();

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -300,7 +300,7 @@ Gtk::ToolItem* ToolBar::get_label()
         m_label = Gtk::manage( new Gtk::Label );
 
         m_label->set_size_request( 0, 0 );
-        m_label->set_alignment( Gtk::ALIGN_LEFT );
+        m_label->set_alignment( Gtk::ALIGN_START );
         m_label->set_selectable( true );
 
         m_ebox_label->add( *m_label );
@@ -624,7 +624,7 @@ Gtk::ToolItem* ToolBar::get_button_board()
     if( ! m_button_board ){
 
         m_label_board = Gtk::manage( new Gtk::Label );
-        m_label_board->set_alignment( Gtk::ALIGN_LEFT );
+        m_label_board->set_alignment( Gtk::ALIGN_START );
 
         m_button_board = Gtk::manage( new SKELETON::ToolMenuButton( CONTROL::get_label( CONTROL::OpenParentBoard ), false, true, *m_label_board ) );
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -221,7 +221,7 @@ const bool JDTreeViewBase::row_down()
     if( !get_row( path ) ) return false;
 
     Gtk::TreePath new_path = next_path( path );
-    if( new_path.get_depth() && get_row( new_path ) ) set_cursor( new_path );
+    if( new_path.size() && get_row( new_path ) ) set_cursor( new_path );
     else return false;
 
     return true;
@@ -246,7 +246,7 @@ void JDTreeViewBase::page_up()
     Gtk::TreePath path;
     if( set_top ) path = get_path_under_xy( 0, (int)adj->get_page_size() - 4 );
     else path = get_path_under_xy( 0, 0 );
-    if( path.get_depth() && get_row( path ) )set_cursor( path );
+    if( path.size() && get_row( path ) )set_cursor( path );
 }
 
 
@@ -268,7 +268,7 @@ void JDTreeViewBase::page_down()
     Gtk::TreePath path;
     if( set_bottom ) path = get_path_under_xy( 0, 0 );
     else path = get_path_under_xy( 0, (int)adj->get_page_size() - 4 );
-    if( path.get_depth() && get_row( path ) ) set_cursor( path );
+    if( path.size() && get_row( path ) ) set_cursor( path );
 }
 
 
@@ -291,7 +291,7 @@ Gtk::TreePath JDTreeViewBase::prev_path( const Gtk::TreePath& path, bool check_e
 
     // 一番上まで到達したらup
     path_out = path;
-    if( ! path_out.prev() && path_out.get_depth() >= 2 ) path_out.up();
+    if( ! path_out.prev() && path_out.size() >= 2 ) path_out.up();
 
     return path_out;;
 }
@@ -314,7 +314,7 @@ Gtk::TreePath JDTreeViewBase::next_path( const Gtk::TreePath& path, bool check_e
 
     // next()してレベルの一番下まで到達したら上のレベルに移動
     path_out = path;
-    while( path_out.next(), ( ! get_row( path_out ) && path_out.get_depth() >=2 ) ) path_out.up();
+    while( path_out.next(), ( ! get_row( path_out ) && path_out.size() >=2 ) ) path_out.up();
 
     return path_out;
 }
@@ -342,12 +342,12 @@ void JDTreeViewBase::expand_parents( const Gtk::TreePath& path )
 {
     if( ! get_model() ) return;
 
-    for( int level = 1; level < path.get_depth(); ++level ){
+    for( Gtk::TreePath::size_type level = 1; level < path.size(); ++level ){
                     
         Gtk::TreeModel::Row row_tmp = get_row( path );
         if( ! row_tmp ) return;
 
-        for( int i = 0; i < path.get_depth() - level; ++i ){
+        for( Gtk::TreePath::size_type i = 0; i < path.size() - level; ++i ){
             if( row_tmp.parent() ) row_tmp = *( row_tmp.parent() );
         }
         Gtk::TreePath path_tmp  = get_model()->get_path( row_tmp );
@@ -363,7 +363,7 @@ const bool JDTreeViewBase::is_expand( const Gtk::TreePath& path )
 {
     Gtk::TreePath parent( path );
 
-    if( path.get_depth() < 2 ) return true;
+    if( path.size() < 2 ) return true;
     if( parent.up() && row_expanded( parent ) ) return true;
     return false;
 }

--- a/src/skeleton/window.cpp
+++ b/src/skeleton/window.cpp
@@ -66,7 +66,7 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     // ステータスバー
 #if GTKMM_CHECK_VERSION(2,5,0)
     m_label_stat.set_size_request( 0, -1 );
-    m_label_stat.set_alignment( Gtk::ALIGN_LEFT );
+    m_label_stat.set_alignment( Gtk::ALIGN_START );
     m_label_stat.set_selectable( true );
     m_label_stat.set_single_line_mode( true );
 
@@ -81,7 +81,7 @@ JDWindow::JDWindow( const bool fold_when_focusout, const bool need_mginfo )
     }
 
     m_mginfo.set_width_chars( MGINFO_CHARS );
-    m_mginfo.set_alignment( Gtk::ALIGN_LEFT );
+    m_mginfo.set_alignment( Gtk::ALIGN_START );
 #else
     if( need_mginfo ) m_statbar.pack_start( m_mginfo );
 #endif

--- a/src/usrcmdpref.cpp
+++ b/src/usrcmdpref.cpp
@@ -25,8 +25,8 @@ using namespace CORE;
 
 UsrCmdDiag::UsrCmdDiag( Gtk::Window* parent, const Glib::ustring& name, const Glib::ustring& cmd )
     : SKELETON::PrefDiag( parent, "" ),
-      m_label_name( "コマンド名", Gtk::ALIGN_LEFT ),
-      m_label_cmd( "実行するコマンド", Gtk::ALIGN_LEFT ),
+      m_label_name( "コマンド名", Gtk::ALIGN_START ),
+      m_label_cmd( "実行するコマンド", Gtk::ALIGN_START ),
       m_button_manual( "オンラインマニュアルの置換文字一覧を表示" )
 {
     resize( 640, 1 );


### PR DESCRIPTION
現在alphaバージョンであるgtk3版からいくつかのコミットを抽出してリクエストします。gtk3版のブランチは変更量が多すぎるので安定している変更を分けたいと思います。

### 修正の内容
廃止予定の機能を同等の機能に置き換える。([deprecated list](https://developer.gnome.org/gtkmm/2.24/deprecated.html)を参照した) gtkmmのドキュメントには特にバージョンが記載されてないので無条件でリプレースする。

### 代替案
非常に古いディストリビューション(例えばRHEL 5)のglibmmはGlib::RefPtr::reset()がないのでコンパイルエラーになる。サポートするには条件コンパイルが必要。