### PR TITLE
Replace incompatible features

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -1098,7 +1098,8 @@ const bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset
     if( ! m_vscrbar && m_height_client > height_view ) create_scrbar();
 
     // adjustment 範囲変更
-    Gtk::Adjustment* adjust = m_vscrbar ? m_vscrbar->get_adjustment(): NULL;
+    auto adjust = m_vscrbar ? m_vscrbar->get_adjustment()
+                            : decltype( m_vscrbar->get_adjustment() )( nullptr );
     if( adjust ){
 
         const double current = adjust->get_value();
@@ -2995,7 +2996,7 @@ void DrawAreaBase::wheelscroll( GdkEventScroll* event )
 
         if( m_vscrbar && ( m_scrollinfo.mode == SCROLL_NOT || m_scrollinfo.mode == SCROLL_NORMAL ) ){
 
-            Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+            const auto adjust = m_vscrbar->get_adjustment();
 
             const int current_y = ( int ) adjust->get_value();
             if( event->direction == GDK_SCROLL_UP && current_y == 0 ) return;
@@ -3076,7 +3077,7 @@ void DrawAreaBase::exec_scroll()
 
     // 移動後のスクロール位置を計算
     int y = 0;
-    Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+    auto adjust = m_vscrbar->get_adjustment();
     const int current_y = ( int ) adjust->get_value();
 
     switch( m_scrollinfo.mode ){
@@ -3678,7 +3679,7 @@ const int DrawAreaBase::search_move( const bool reverse )
             std::cout << "move to y = " << y << std::endl;
 #endif
 
-            Gtk::Adjustment* adjust = m_vscrbar->get_adjustment();
+            auto adjust = m_vscrbar->get_adjustment();
             if( ( int ) adjust->get_value() > y || ( int ) adjust->get_value() + ( int ) adjust->get_page_size() - m_font->br_size < y ){
 
                 m_cancel_change_adjust = true;

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -590,7 +590,7 @@ void BBSListViewBase::clock_in()
     // 初期化直後など、まだスクロールバーが表示されてない時があるので表示されるまでジャンプしない
     if( m_jump_y != -1 ){
 
-        Gtk::Adjustment* adjust = m_treeview.get_vadjustment();
+        auto adjust = m_treeview.get_vadjustment();
         if( adjust && adjust->get_upper() > m_jump_y ){
 
 #ifdef _DEBUG
@@ -2246,7 +2246,7 @@ void BBSListViewBase::tree2xml( const std::string& root_name )
 
     // 座標
     int y = 0;
-    Gtk::Adjustment* adjust = m_treeview.get_vadjustment();
+    const auto adjust = m_treeview.get_vadjustment();
     if( adjust )
     {
         if( m_jump_y != -1 && adjust->get_upper() > m_jump_y ) y = m_jump_y;

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2779,7 +2779,7 @@ void BBSListViewBase::exec_search()
             // 先頭にいるときは最後に戻る
             if( path == GET_PATH( *( m_treestore->children().begin() ) ) ){
 
-                path = GET_PATH( *( m_treestore->children().rbegin() ) );
+                path = GET_PATH( *( std::prev( m_treestore->children().end() ) ) );
                 Gtk::TreePath path_tmp = path;
                 while( m_treeview.get_row( path_tmp ) ){
                     path = path_tmp;
@@ -2954,13 +2954,17 @@ void BBSListViewBase::append_history()
     m_treeview.append_one_row( ( *it_info ).url, ( *it_info ).name, ( *it_info ).type, ( *it_info ).dirid, ( *it_info ).data, path, before, subdir );
 
     // サイズが越えていたら最後を削除
-    while( ( int )m_treestore->children().size() > CONFIG::get_historyview_size() ){
-
-        Gtk::TreeModel::Row row = *( m_treestore->children().rbegin() );
-        m_treestore->erase( row );
+    const Gtk::TreeNodeChildren children = m_treestore->children();
+    const int history_size = CONFIG::get_historyview_size();
+    if( static_cast< int >( children.size() ) > history_size ) {
+        const auto end = children.end();
+        auto it = std::next( children.begin(), history_size );
+        while( it != end ) {
+            it = m_treestore->erase( *it );
 #ifdef _DEBUG
-        std::cout << "erase bottom\n";
+            std::cout << "erase bottom\n";
 #endif
+        }
     }
 
     goto_top();

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -37,7 +37,6 @@
 
 #include "icons/iconmanager.h"
 
-#include <gtk/gtk.h> // m_liststore->gobj()->sort_column_id = -2
 #include <sstream>
 
 using namespace BOARD;
@@ -503,7 +502,8 @@ const int BoardViewBase::get_row_size()
 //
 void BoardViewBase::unsorted_column()
 {
-    m_liststore->gobj()->sort_column_id = -2;
+    m_liststore->set_sort_column( Gtk::TreeSortable::DEFAULT_UNSORTED_COLUMN_ID,
+                                  Gtk::SortType::SORT_ASCENDING );
 }
 
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2648,7 +2648,9 @@ void BoardViewBase::exec_search()
     Gtk::TreePath path = m_treeview.get_current_path();;
     if( path.empty() ){
         if( m_search_invert ) path = GET_PATH( *( m_liststore->children().begin() ) );
-        else GET_PATH( *( m_liststore->children().rbegin() ) );
+        else {
+            GET_PATH( *( std::prev( m_liststore->children().end() ) ) );
+        }
     }
 
     Gtk::TreePath path_start = path;
@@ -2675,7 +2677,7 @@ void BoardViewBase::exec_search()
             // 前へ
             if( ! path.prev() ){
                 // 一番後へ
-                path =  GET_PATH( *( m_liststore->children().rbegin() ) );
+                path = GET_PATH( *( std::prev( m_liststore->children().end() ) ) );
             }
         }
 

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -1624,7 +1624,7 @@ void BoardViewBase::goto_num( const int num, const int )
 //
 void BoardViewBase::scroll_left()
 {
-    Gtk::Adjustment*  hadjust = m_scrwin.get_hadjustment();
+    auto hadjust = m_scrwin.get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value( MAX( 0,  hadjust->get_value() - hadjust->get_step_increment() ) );
 }
@@ -1635,7 +1635,7 @@ void BoardViewBase::scroll_left()
 //
 void BoardViewBase::scroll_right()
 {
-    Gtk::Adjustment*  hadjust = m_scrwin.get_hadjustment();
+    auto hadjust = m_scrwin.get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value(  MIN( hadjust->get_upper() - hadjust->get_page_size(),
                               hadjust->get_value() + hadjust->get_step_increment() ) );

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -419,7 +419,7 @@ void MouseKeyDiag::slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::Tr
 // 行削除
 void MouseKeyDiag::slot_delete()
 {
-    std::list< Gtk::TreeModel::Path > rows = m_treeview.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > rows = m_treeview.get_selection()->get_selected_rows();
     if( ! rows.size() ) return;
 
     Gtk::TreeModel::Path path = *rows.begin();

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -469,11 +469,11 @@ void FontColorPref::slot_change_color()
 {
     Gtk::TreeModel::Path path;
     Gtk::TreeRow row;
-    
-    std::list< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
+
+    std::vector< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
     if( selection_path.empty() ) return;
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
 
     int colorid = COLOR_NONE;
     if( selection_path.size() == 1 ){
@@ -521,10 +521,10 @@ void FontColorPref::slot_change_color()
 //
 void FontColorPref::slot_reset_color()
 {
-    std::list< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_treeview_color.get_selection()->get_selected_rows();
     if( selection_path.empty() ) return;
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
 
     for( ; it != selection_path.end(); ++it ){
 

--- a/src/image/imageadmin.cpp
+++ b/src/image/imageadmin.cpp
@@ -838,7 +838,7 @@ void ImageAdmin::switch_img( const std::string& url )
     if( view_icon ) view_icon->set_command( "switch_icon" );
 
     // タブをスクロール
-    Gtk::Adjustment* adjust = m_scrwin.get_hadjustment();
+    auto adjust = m_scrwin.get_hadjustment();
     if( page != -1 && adjust ){
         double pos = adjust->get_value();
         double upper =  m_list_view.size() * ICON_SIZE;
@@ -957,7 +957,7 @@ void ImageAdmin::scroll_tab( int scroll )
     std::cout << "ImageAdmin::scroll_tab " << scroll << std::endl;
 #endif
 
-    Gtk::Adjustment* adjust = m_scrwin.get_hadjustment();
+    auto adjust = m_scrwin.get_hadjustment();
     if( adjust ){
         double pos = adjust->get_value();
         double upper = adjust->get_upper();

--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -464,8 +464,8 @@ bool ImageViewMain::slot_motion_notify( GdkEventMotion* event )
             || ( ( event->state & GDK_BUTTON3_MASK ) && event_button.button == 3 )
             ){
 
-            Gtk::Adjustment* hadj = m_scrwin->get_hadjustment();
-            Gtk::Adjustment* vadj = m_scrwin->get_vadjustment();
+            auto hadj = m_scrwin->get_hadjustment();
+            auto vadj = m_scrwin->get_vadjustment();
 
             gdouble dx = event->x_root - m_x_motion;
             gdouble dy = event->y_root - m_y_motion;
@@ -500,7 +500,7 @@ void ImageViewMain::scroll_up()
     std::cout << "ImageViewMain::scroll_up\n";
 #endif
 
-    Gtk::Adjustment*  vadjust = m_scrwin->get_vadjustment();
+    auto vadjust = m_scrwin->get_vadjustment();
     if( !vadjust ) return;
     vadjust->set_value( MAX( 0,  vadjust->get_value() - vadjust->get_step_increment() ) );
 }
@@ -515,7 +515,7 @@ void ImageViewMain::scroll_down()
     std::cout << "ImageViewMain::scroll_down\n";
 #endif
 
-    Gtk::Adjustment*  vadjust = m_scrwin->get_vadjustment();
+    auto vadjust = m_scrwin->get_vadjustment();
     if( !vadjust ) return;
     vadjust->set_value(  MIN( vadjust->get_upper() - vadjust->get_page_size(),
                               vadjust->get_value() + vadjust->get_step_increment() ) );
@@ -531,7 +531,7 @@ void ImageViewMain::scroll_left()
     std::cout << "ImageViewMain::scroll_left\n";
 #endif
 
-    Gtk::Adjustment*  hadjust = m_scrwin->get_hadjustment();
+    auto hadjust = m_scrwin->get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value( MAX( 0,  hadjust->get_value() - hadjust->get_step_increment() ) );
 }
@@ -546,7 +546,7 @@ void ImageViewMain::scroll_right()
     std::cout << "ImageViewMain::scroll_right\n";
 #endif
 
-    Gtk::Adjustment*  hadjust = m_scrwin->get_hadjustment();
+    auto hadjust = m_scrwin->get_hadjustment();
     if( !hadjust ) return;
     hadjust->set_value(  MIN( hadjust->get_upper() - hadjust->get_page_size(),
                               hadjust->get_value() + hadjust->get_step_increment() ) );

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -47,7 +47,7 @@ ImageViewIcon::ImageViewIcon( const std::string& url )
     setup_common();
 
     // D&D可能にする
-    std::list< Gtk::TargetEntry > targets;
+    std::vector< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( DNDTARGET_IMAGETAB, Gtk::TARGET_SAME_APP, 0 ) );
     get_event().drag_dest_set( targets );
 

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -149,7 +149,7 @@ const Gtk::TreeModel::iterator LinkFilterPref::get_selected_row()
 {
     Gtk::TreeModel::iterator row;
 
-    std::list< Gtk::TreeModel::Path > paths = m_treeview.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > paths = m_treeview.get_selection()->get_selected_rows();
     if( ! paths.size() ) return row;
 
     row = *( m_liststore->get_iter( *paths.begin() ) );

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -58,7 +58,7 @@ DragTreeView::DragTreeView( const std::string& url, const std::string& dndtarget
     get_selection()->signal_changed().connect( sigc::mem_fun( *this, &DragTreeView::slot_selection_changed ) );
 
     // D&D 設定
-    std::list< Gtk::TargetEntry > targets;
+    std::vector< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( get_dndtarget(), Gtk::TARGET_SAME_APP, 0 ) );
 
     // ドラッグ開始ボタン設定
@@ -89,7 +89,7 @@ DragTreeView::~DragTreeView()
 //
 void DragTreeView::set_enable_drop_uri_list()
 {
-    std::list< Gtk::TargetEntry > targets_drop;
+    std::vector< Gtk::TargetEntry > targets_drop;
     targets_drop.push_back( Gtk::TargetEntry( "text/uri-list" ) );
 
     // ドロップされると on_drag_data_received() が呼び出される

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -499,7 +499,7 @@ bool DragTreeView::on_scroll_event( GdkEventScroll* event )
 //
 void DragTreeView::wheelscroll( GdkEventScroll* event )
 {
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
 
     int scr_inc = get_row_height() * CONFIG::get_tree_scroll_size();

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -248,7 +248,7 @@ void EditTreeView::clock_in()
             m_dnd_counter = 0;
 
             Gtk::TreePath path = get_path_under_mouse();
-            Gtk::Adjustment* adjust = get_vadjustment();
+            auto adjust = get_vadjustment();
 
             if( get_row( path ) && adjust ){
 

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -225,7 +225,7 @@ void EditTreeView::set_editable_view( const bool editable )
     if( m_editable ){
 
         // D&D のドロップを可能にする
-        std::list< Gtk::TargetEntry > targets;
+        std::vector< Gtk::TargetEntry > targets;
         targets.push_back( Gtk::TargetEntry( get_dndtarget(), Gtk::TARGET_SAME_APP, 0 ) );
         drag_dest_set( targets );
     }

--- a/src/skeleton/edittreeview.cpp
+++ b/src/skeleton/edittreeview.cpp
@@ -1369,7 +1369,7 @@ void EditTreeView::replace_infopath( CORE::DATA_INFO_LIST& list_info,
 
         if( children.empty() ) path = Gtk::TreePath( "0" );
         else{
-            path = get_model()->get_path( *( children.rbegin() ) );
+            path = get_model()->get_path( *( std::prev( children.end() ) ) );
             path.next();
         }
     }

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -391,8 +391,8 @@ void SelectItemPref::slot_top()
     // 移動先のイテレータ
     Gtk::TreeIter upper_it = children.begin();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreeIter src_it = m_store_shown->get_iter( *it );
@@ -428,8 +428,8 @@ void SelectItemPref::slot_up()
     // 上限のイテレータ
     Gtk::TreeIter upper_it = children.begin();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreePath src = *it;
@@ -469,8 +469,8 @@ void SelectItemPref::slot_down()
     // 下限のイテレータ
     Gtk::TreeIter bottom_it = --children.end();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
     while( it != selection_path.rend() )
     {
         Gtk::TreePath src = *it;
@@ -512,8 +512,8 @@ void SelectItemPref::slot_bottom()
     // 移動先のイテレータ
     Gtk::TreeIter bottom_it = children.end();
 
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
-    std::list< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath >::reverse_iterator it = selection_path.rbegin();
     while( it != selection_path.rend() )
     {
         Gtk::TreeIter src_it = m_store_shown->get_iter( *it );
@@ -543,7 +543,7 @@ void SelectItemPref::slot_bottom()
 //
 void SelectItemPref::slot_delete()
 {
-    std::list< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_tree_shown.get_selection()->get_selected_rows();
 
     // 選択したアイテムが無い場合はフォーカスだけ移して出る
     if( selection_path.empty() )
@@ -555,7 +555,7 @@ void SelectItemPref::slot_delete()
     std::list< Gtk::TreeRow > erase_rows;
     bool set_cursor = true;  // 一番上の選択項目にカーソルをセット
 
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreePath path = *it;
@@ -598,7 +598,7 @@ void SelectItemPref::slot_delete()
 //
 void SelectItemPref::slot_add()
 {
-    std::list< Gtk::TreePath > selection_path = m_tree_hidden.get_selection()->get_selected_rows();
+    std::vector< Gtk::TreePath > selection_path = m_tree_hidden.get_selection()->get_selected_rows();
 
     // 選択したアイテムが無い場合はフォーカスだけ移して出る
     if( selection_path.empty() )
@@ -611,7 +611,7 @@ void SelectItemPref::slot_add()
     bool set_cursor = true; // 一番上の選択項目にカーソルをセット
 
     // 選択したアイテムを追加
-    std::list< Gtk::TreePath >::iterator it = selection_path.begin();
+    std::vector< Gtk::TreePath >::iterator it = selection_path.begin();
     while( it != selection_path.end() )
     {
         Gtk::TreeRow row = *m_store_hidden->get_iter( *it );

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -108,7 +108,7 @@ void SelectItemPref::pack_widgets()
     m_vbuttonbox_v.set_spacing( 4 );
     m_vbox.pack_start( m_vbuttonbox_v, Gtk::PACK_EXPAND_WIDGET );
 
-    m_vbuttonbox_h.set_layout( Gtk::BUTTONBOX_DEFAULT_STYLE );
+    m_vbuttonbox_h.set_layout( Gtk::BUTTONBOX_EDGE );
     m_vbuttonbox_h.set_spacing( 4 );
     m_vbox.pack_start( m_vbuttonbox_h, Gtk::PACK_SHRINK );
 

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -93,7 +93,7 @@ void TabLabel::set_dragable( bool dragable, int button )
 {
     if( dragable ){
 
-        std::list< Gtk::TargetEntry > targets;
+        std::vector< Gtk::TargetEntry > targets;
         targets.push_back( Gtk::TargetEntry( DNDTARGET_FAVORITE, Gtk::TARGET_SAME_APP, 0 ) );
         targets.push_back( Gtk::TargetEntry( DNDTARGET_TAB, Gtk::TARGET_SAME_APP, 0 ) );
 

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -365,7 +365,7 @@ TabNotebook::TabNotebook( DragableNoteBook* parent )
     // ドロップ側に設定する
     drag_source_unset();
     drag_dest_unset();
-    std::list< Gtk::TargetEntry > targets;
+    std::vector< Gtk::TargetEntry > targets;
     targets.push_back( Gtk::TargetEntry( DNDTARGET_TAB, Gtk::TARGET_SAME_APP, 0 ) );
     drag_dest_set( targets, Gtk::DEST_DEFAULT_MOTION | Gtk::DEST_DEFAULT_DROP );
 

--- a/src/skeleton/toolbar.cpp
+++ b/src/skeleton/toolbar.cpp
@@ -206,8 +206,8 @@ void ToolBar::update_button()
 // ボタンのアンパック
 void ToolBar::unpack_buttons()
 {
-    std::list< Gtk::Widget* > lists = m_buttonbar.get_children();
-    std::list< Gtk::Widget* >::iterator it = lists.begin();
+    std::vector< Gtk::Widget* > lists = m_buttonbar.get_children();
+    std::vector< Gtk::Widget* >::iterator it = lists.begin();
     for( ; it != lists.end(); ++it ){
         m_buttonbar.remove( *(*it) );
         if( dynamic_cast< Gtk::SeparatorToolItem* >( *it ) ) delete *it;
@@ -219,8 +219,8 @@ void ToolBar::unpack_search_buttons()
 {
     if( ! m_searchbar ) return;
 
-    std::list< Gtk::Widget* > lists = m_searchbar->get_children();
-    std::list< Gtk::Widget* >::iterator it = lists.begin();
+    std::vector< Gtk::Widget* > lists = m_searchbar->get_children();
+    std::vector< Gtk::Widget* >::iterator it = lists.begin();
     for( ; it != lists.end(); ++it ){
         m_searchbar->remove( *(*it) );
         if( dynamic_cast< Gtk::SeparatorToolItem* >( *it ) ) delete *it;
@@ -230,15 +230,15 @@ void ToolBar::unpack_search_buttons()
 // ボタンのrelief指定
 void ToolBar::set_relief()
 {
-    std::list< Gtk::Widget* > lists_toolbar = get_children();
-    std::list< Gtk::Widget* >::iterator it_toolbar = lists_toolbar.begin();
+    std::vector< Gtk::Widget* > lists_toolbar = get_children();
+    std::vector< Gtk::Widget* >::iterator it_toolbar = lists_toolbar.begin();
     for( ; it_toolbar != lists_toolbar.end(); ++it_toolbar ){
 
         Gtk::Toolbar* toolbar = dynamic_cast< Gtk::Toolbar* >( *it_toolbar );
         if( ! toolbar ) continue;
 
-        std::list< Gtk::Widget* > lists = toolbar->get_children();
-        std::list< Gtk::Widget* >::iterator it = lists.begin();
+        std::vector< Gtk::Widget* > lists = toolbar->get_children();
+        std::vector< Gtk::Widget* >::iterator it = lists.begin();
         for( ; it != lists.end(); ++it ){
 
             Gtk::Button* button = NULL;

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -179,7 +179,7 @@ void JDTreeViewBase::goto_bottom()
 {
     if( ! get_row_size() ) return;
 
-    Gtk::TreePath path = get_model()->get_path( *( get_model()->children().rbegin() ) );
+    Gtk::TreePath path = get_model()->get_path( *( std::prev( get_model()->children().end() ) ) );
 
     // ディレクトリを開いている時、一番下の行に移動
     Gtk::TreePath path_prev = path;

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -40,11 +40,11 @@ const int JDTreeViewBase::get_row_size()
 Gtk::TreeModel::Path JDTreeViewBase::get_current_path()
 {
     Gtk::TreeModel::Path path;
-    
-    std::list< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
+
+    std::vector< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
     if( paths.size() ){
-    
-        std::list< Gtk::TreeModel::Path >::iterator it = paths.begin();
+
+        std::vector< Gtk::TreeModel::Path >::iterator it = paths.begin();
         path = ( *it );
     }
 
@@ -115,8 +115,8 @@ std::list< Gtk::TreeModel::iterator > JDTreeViewBase::get_selected_iterators()
     
     if( get_model() ){
 
-        std::list< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
-        std::list< Gtk::TreeModel::Path >::iterator it = paths.begin();
+        std::vector< Gtk::TreeModel::Path > paths = get_selection()->get_selected_rows();
+        std::vector< Gtk::TreeModel::Path >::iterator it = paths.begin();
         for( ; it != paths.end(); ++it ) list_it.push_back( get_model()->get_iter( ( *it ) ) );
     }
 
@@ -129,7 +129,7 @@ std::list< Gtk::TreeModel::iterator > JDTreeViewBase::get_selected_iterators()
 //
 void JDTreeViewBase::delete_selected_rows( const bool force )
 {
-    std::list< Gtk::TreeModel::Path > list_path = get_selection()->get_selected_rows();
+    std::vector< Gtk::TreeModel::Path > list_path = get_selection()->get_selected_rows();
 
     if( ! list_path.size() ) return;
 
@@ -146,7 +146,7 @@ void JDTreeViewBase::delete_selected_rows( const bool force )
     const bool gotobottom = ( ! get_row( next ) );
     if( ! gotobottom ) set_cursor( next );
 
-    std::list< Gtk::TreePath >::reverse_iterator it = list_path.rbegin();
+    std::vector< Gtk::TreePath >::reverse_iterator it = list_path.rbegin();
     for( ; it != list_path.rend(); ++it ){
         Gtk::TreeRow row = get_row( *it );
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -236,7 +236,7 @@ void JDTreeViewBase::page_up()
     bool set_top = false;
 
     // スクロール
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
     if( val > adj->get_page_size()/2 ) set_top = true;
     val = MAX( 0, val - adj->get_page_size() );
@@ -258,7 +258,7 @@ void JDTreeViewBase::page_down()
     bool set_bottom = false;
 
     // スクロール
-    Gtk::Adjustment *adj = get_vadjustment();
+    auto adj = get_vadjustment();
     double val = adj->get_value();
     if( val < adj->get_upper() - adj->get_page_size() - adj->get_page_size()/2 ) set_bottom = true;
     val = MIN( adj->get_upper() - adj->get_page_size(), val + adj->get_page_size() );

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -46,7 +46,7 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 #ifndef _WIN32
     // アイコンをセット
     // WindowsはwindresのデフォルトICONが初期適用されるので不要
-    std::list< Glib::RefPtr< Gdk::Pixbuf > > list_icons;
+    std::vector< Glib::RefPtr< Gdk::Pixbuf > > list_icons;
     list_icons.push_back( ICON::get_icon( ICON::JD16 ) );
     list_icons.push_back( ICON::get_icon( ICON::JD32 ) );
     list_icons.push_back( ICON::get_icon( ICON::JD48 ) );


### PR DESCRIPTION
現在alphaバージョンであるgtk3版からいくつかのコミットを抽出してリクエストします。gtk3版のブランチは変更量が多すぎるので安定している変更を分けたいと思います。

### 修正の内容
互換性の問題からコンパイルエラーやクラッシュの原因となる機能を修正する。`Gtk::BUTTONBOX_EDGE`の修正はgtk2版の事実上のデフォルトであるとgtkのソースコードから推定した（[コミットメッセージ](https://github.com/yama-natuki/JD/commit/2f5a8319ad78652b4e4540eb8d61f4c833b1e969)を参照）。

### 代替案
修正はgtk2版の問題ではないためgtk3版でビルドするときのみ有効（＝条件コンパイル）にする。
