### PR TITLE
Add support for std::thread

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -93,9 +93,9 @@
 
        正規表現ライブラリとしてPOSIX regex の代わりにPCREを使用する。PCREはBSDライセンスなのでJDをバイナリ配布する場合には注意すること(ライセンスはGPLになる)。UTF-8が有効な ( --enable-utf オプションを用いて make する ) PCRE 6.5 以降が必要となる。Perl互換の正規表現なので、従来の POSIX 拡張の正規表現から設定変更が必要になる場合がある。
 
-    --with-gthread
+    --with-[gthread|stdthread]
 
-       pthreadの代わりにgthreadを使用する。
+       pthreadの代わりにgthreadまたはstd::threadを使用する。
 
 * メモ
 

--- a/configure.ac
+++ b/configure.ac
@@ -389,11 +389,35 @@ AC_ARG_WITH(pcre,[ --with-pcre    (enable PCRE)],
 dnl
 dnl checking gthread
 dnl
-AC_ARG_WITH(gthread,[ --with-gthread    (use gthread instead of pthread)],
-       [ if test "$withval" ;then
-               echo "use gthread"
-               AC_DEFINE(USE_GTHREAD, , "use gthread")
-       fi ])
+AC_MSG_CHECKING(for --with-gthread)
+AC_ARG_WITH(gthread,
+  AS_HELP_STRING([--with-gthread],
+                 [use gthread instead of pthread [default=no]]),
+  [with_gthread="$withval"],
+  [with_gthread=no])
+AC_MSG_RESULT($with_gthread)
+
+
+dnl
+dnl checking std::thread
+dnl
+AC_MSG_CHECKING(for --with-stdthread)
+AC_ARG_WITH(stdthread,
+  AS_HELP_STRING([--with-stdthread],
+                 [use std::thread instead of pthread [default=no]]),
+  [with_stdthread="$withval"],
+  [with_stdthread=no])
+AC_MSG_RESULT($with_stdthread)
+
+
+AS_IF(
+  [test "x$with_gthread" = xyes -a "x$with_stdthread" = xyes],
+  [AC_MSG_ERROR([cannot configure both gthread and stdthread.])],
+  [test "x$with_gthread" = xyes],
+  [AC_DEFINE(USE_GTHREAD, , [use gthread instead of pthread])],
+  [test "x$with_stdthread" = xyes],
+  [AC_DEFINE(WITH_STD_THREAD, 1, [Use std::thread instead of pthread])]
+)
 
 
 dnl

--- a/src/article/embeddedimage.cpp
+++ b/src/article/embeddedimage.cpp
@@ -7,6 +7,7 @@
 #include "articleadmin.h"
 
 #include "jdlib/imgloader.h"
+#include "jdlib/jdmutex.h"
 #include "jdlib/miscmsg.h"
 
 #include "dbimg/imginterface.h"
@@ -19,7 +20,7 @@
 //
 // スレッドのランチャ
 //
-Glib::StaticMutex eimg_launcher_mutex = GLIBMM_STATIC_MUTEX_INIT;
+static JDLIB::StaticMutex eimg_launcher_mutex = JDLIB_STATIC_MUTEX_INIT;
 int redraw_counter = 0; // 0 になったとき再描画する
 
 void* eimg_launcher( void* dat )
@@ -28,7 +29,7 @@ void* eimg_launcher( void* dat )
 
     // 遅いCPUの場合は同時に画像をリサイズしようとすると固まった様になるので
     // mutexをかけて同時にリサイズしないようにする
-    Glib::Mutex::Lock lock( eimg_launcher_mutex );
+    JDLIB::LockGuard lock( eimg_launcher_mutex );
 
 #ifdef _DEBUG
     std::cout << "start eimg_launcher" << std::endl;

--- a/src/dispatchmanager.cpp
+++ b/src/dispatchmanager.cpp
@@ -5,10 +5,11 @@
 
 #include "dispatchmanager.h"
 
+#include "jdlib/jdmutex.h"
 #include "skeleton/dispatchable.h"
 
 
-Glib::StaticMutex dispatch_mutex = GLIBMM_STATIC_MUTEX_INIT;
+static JDLIB::StaticMutex dispatch_mutex = JDLIB_STATIC_MUTEX_INIT;
 CORE::DispatchManager* instance_dispmanager = NULL;
 
 
@@ -51,7 +52,7 @@ DispatchManager::~DispatchManager()
 
 void DispatchManager::add( SKELETON::Dispatchable* child )
 {
-    Glib::Mutex::Lock lock( dispatch_mutex );
+    JDLIB::LockGuard lock( dispatch_mutex );
 
     // 既にlistに登録されていたらキャンセルする
     std::list< SKELETON::Dispatchable* >::iterator it = m_children.begin();
@@ -75,7 +76,7 @@ void DispatchManager::add( SKELETON::Dispatchable* child )
 
 void DispatchManager::remove( SKELETON::Dispatchable* child )
 {
-    Glib::Mutex::Lock lock( dispatch_mutex );
+    JDLIB::LockGuard lock( dispatch_mutex );
 
     size_t size = m_children.size();
     if( ! size  ) return;
@@ -91,7 +92,7 @@ void DispatchManager::remove( SKELETON::Dispatchable* child )
 
 void DispatchManager::slot_dispatch()
 {
-    Glib::Mutex::Lock lock( dispatch_mutex );
+    JDLIB::UniqueLock lock( dispatch_mutex );
 
     const size_t size = m_children.size();
     if( ! size  ) return;
@@ -101,7 +102,7 @@ void DispatchManager::slot_dispatch()
     // child->callback_dispatch()の中で再び Dispatchable::add()が呼び出されると
     // キャンセルされてしまうので callback_dispatch() を呼び出す前にremoveする
     m_children.remove( child );
-    lock.release();
+    JDLIB::unique_unlock( lock );
 
     if( child ) child->callback_dispatch();
 

--- a/src/image/imageareabase.cpp
+++ b/src/image/imageareabase.cpp
@@ -5,6 +5,7 @@
 
 #include "imageareabase.h"
 
+#include "jdlib/jdmutex.h"
 #include "jdlib/miscmsg.h"
 
 #include "dbimg/imginterface.h"
@@ -15,11 +16,11 @@
 //
 // スレッドのランチャ
 //
-Glib::StaticMutex imgarea_launcher_mutex = GLIBMM_STATIC_MUTEX_INIT;
+static JDLIB::StaticMutex imgarea_launcher_mutex = JDLIB_STATIC_MUTEX_INIT;
 
 void* imgarea_launcher( void* dat )
 {
-    Glib::Mutex::Lock lock( imgarea_launcher_mutex);
+    JDLIB::LockGuard lock( imgarea_launcher_mutex );
 
 #ifdef _DEBUG
     std::cout << "start imgarea_launcher" << std::endl;

--- a/src/jdlib/imgloader.cpp
+++ b/src/jdlib/imgloader.cpp
@@ -43,7 +43,7 @@ ImgLoader::~ImgLoader()
 Glib::RefPtr< ImgLoader > ImgLoader::get_loader( const std::string& file )
 {
     ImgProvider& provider = ImgProvider::get_provider();
-    Glib::Mutex::Lock lock( provider.m_provider_lock );
+    JDLIB::LockGuard lock( provider.m_provider_lock );
     Glib::RefPtr< ImgLoader > loader = provider.get_loader( file );
     if( ! loader ) {
         loader = Glib::RefPtr< ImgLoader >( new ImgLoader( file ) );
@@ -58,7 +58,7 @@ Glib::RefPtr< ImgLoader > ImgLoader::get_loader( const std::string& file )
 // 画像サイズ取得
 bool ImgLoader::get_size( int& width, int& height )
 {
-    Glib::Mutex::Lock lock( m_loader_lock );
+    JDLIB::LockGuard lock( m_loader_lock );
     bool ret = load_imgfile( LOADLEVEL_SIZEONLY );
     width = m_width;
     height = m_height;
@@ -68,7 +68,7 @@ bool ImgLoader::get_size( int& width, int& height )
 Glib::RefPtr< Gdk::Pixbuf > ImgLoader::get_pixbuf( const bool pixbufonly )
 {
     Glib::RefPtr< Gdk::Pixbuf > ret;
-    Glib::Mutex::Lock lock( m_loader_lock );
+    JDLIB::LockGuard lock( m_loader_lock );
     if( load_imgfile( pixbufonly ? LOADLEVEL_PIXBUFONLY : LOADLEVEL_NORMAL ) ) {
         ret = m_loader->get_pixbuf();
     }
@@ -78,7 +78,7 @@ Glib::RefPtr< Gdk::Pixbuf > ImgLoader::get_pixbuf( const bool pixbufonly )
 Glib::RefPtr< Gdk::PixbufAnimation > ImgLoader::get_animation()
 {
     Glib::RefPtr< Gdk::PixbufAnimation > ret;
-    Glib::Mutex::Lock lock( m_loader_lock );
+    JDLIB::LockGuard lock( m_loader_lock );
     if( load_imgfile( LOADLEVEL_NORMAL ) ) {
         ret = m_loader->get_animation();
     }
@@ -89,7 +89,7 @@ Glib::RefPtr< Gdk::PixbufAnimation > ImgLoader::get_animation()
 // 動画でpixbufonly = true の時はアニメーションさせない
 const bool ImgLoader::load( const bool pixbufonly )
 {
-    Glib::Mutex::Lock lock( m_loader_lock );
+    JDLIB::LockGuard lock( m_loader_lock );
     return load_imgfile( pixbufonly ? LOADLEVEL_PIXBUFONLY : LOADLEVEL_NORMAL );
 }
 

--- a/src/jdlib/imgloader.h
+++ b/src/jdlib/imgloader.h
@@ -9,6 +9,8 @@
 
 #include <gtkmm.h>
 
+#include "jdmutex.h"
+
 namespace JDLIB
 {
     // 画像ロードレベル、必要なデータ量順に定義
@@ -24,7 +26,7 @@ namespace JDLIB
     class ImgLoader : public Glib::Object
     {
         Glib::RefPtr< Gdk::PixbufLoader > m_loader;
-        Glib::Mutex m_loader_lock;
+        JDLIB::Mutex m_loader_lock;
         
         std::string m_file;
         std::string m_errmsg;
@@ -64,7 +66,7 @@ namespace JDLIB
         std::list< Glib::RefPtr< ImgLoader > > m_cache;
         
     public:
-        Glib::Mutex m_provider_lock; // ImgProvider操作時の必須ロック
+        JDLIB::Mutex m_provider_lock; // ImgProvider操作時の必須ロック
         
     public:
         virtual ~ImgProvider(){}

--- a/src/jdlib/jdmutex.h
+++ b/src/jdlib/jdmutex.h
@@ -1,0 +1,52 @@
+// ライセンス: GPL2
+
+// ミューテックス
+
+#ifndef JDMUTEX_H
+#define JDMUTEX_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef WITH_STD_THREAD
+#include <mutex>
+#else
+#include <glibmm/thread.h>
+#endif
+
+
+namespace JDLIB
+{
+#ifdef WITH_STD_THREAD
+    using Mutex = std::mutex;
+    using StaticMutex = std::mutex;
+
+    using LockGuard = std::lock_guard< std::mutex >;
+    using UniqueLock = std::unique_lock< std::mutex >;
+#else
+    using Mutex = Glib::Mutex;
+    using StaticMutex = Glib::StaticMutex;
+
+    using LockGuard = Glib::Mutex::Lock;
+    using UniqueLock = Glib::Mutex::Lock;
+#endif
+
+    static inline void unique_unlock( UniqueLock& lock )
+    {
+#ifdef WITH_STD_THREAD
+        lock.unlock();
+#else
+        lock.release();
+#endif
+    }
+}
+
+#ifdef WITH_STD_THREAD
+// std::mutexは初期化子を必要としないがglibmmに合わせる
+#define JDLIB_STATIC_MUTEX_INIT {}
+#else
+#define JDLIB_STATIC_MUTEX_INIT GLIBMM_STATIC_MUTEX_INIT
+#endif
+
+#endif

--- a/src/jdlib/jdthread.cpp
+++ b/src/jdlib/jdthread.cpp
@@ -8,6 +8,9 @@
 
 #include <limits.h>
 #include <cstring>
+#ifdef WITH_STD_THREAD
+#include <system_error>
+#endif
 
 using namespace JDLIB;
 
@@ -48,7 +51,29 @@ const bool Thread::create( STARTFUNC func , void* arg, const bool detach, const 
         return false;
     }
 
-#ifdef USE_GTHREAD // gthread 使用
+#if defined( WITH_STD_THREAD ) // std::thread 使用
+    static_cast< void >( stack_kbyte );
+
+#ifdef _DEBUG
+    std::cout << "Thread::create (stdthread)\n";
+#endif
+    try {
+        m_thread = std::thread( func, arg );
+    }
+    catch( std::system_error& err ) {
+        MISC::ERRMSG( err.what() );
+        return false;
+    }
+
+    if( detach ) {
+#ifdef _DEBUG
+        std::cout << "detach\n";
+#endif
+        m_thread.detach();
+        assert( m_thread.get_id() == std::thread::id() );
+    }
+
+#elif defined( USE_GTHREAD ) // gthread 使用
 
 #ifdef _DEBUG
     std::cout << "Thread::create (gthread)\n";
@@ -117,7 +142,13 @@ const bool Thread::join()
     std::cout << "Thread:join thread = " << m_thread << std::endl;
 #endif
 
-#ifdef USE_GTHREAD // gthread 使用
+#if defined( WITH_STD_THREAD ) // std::thread 使用
+    if( m_thread.joinable() ) {
+        m_thread.join();
+    }
+    JDTH_CLEAR( m_thread );
+
+#elif defined( USE_GTHREAD ) // gthread 使用
 
     if( m_thread->joinable() ){
         m_thread->join();

--- a/src/jdlib/jdthread.h
+++ b/src/jdlib/jdthread.h
@@ -9,7 +9,12 @@
 #include "config.h"
 #endif
 
-#ifdef USE_GTHREAD
+#if defined( WITH_STD_THREAD )
+#include <thread>
+#define JDTH_TYPE std::thread
+#define JDTH_ISRUNNING( pth ) ( ( pth ).get_id() != std::thread::id() )
+#define JDTH_CLEAR( pth ) ( ( pth ) = std::thread() )
+#elif defined( USE_GTHREAD )
 #include <gtkmm.h>
 #define JDTH_TYPE Glib::Thread*
 #define JDTH_ISRUNNING( pth ) ( ( pth ) != NULL )

--- a/src/jdlib/timeout.cpp
+++ b/src/jdlib/timeout.cpp
@@ -14,7 +14,7 @@ using namespace JDLIB;
 
 #ifdef _WIN32
 // static
-Glib::StaticMutex Timeout::s_lock = GLIBMM_STATIC_MUTEX_INIT;
+JDLIB::StaticMutex Timeout::s_lock = JDLIB_STATIC_MUTEX_INIT;
 std::map< UINT_PTR, Timeout* > Timeout::s_timeouts;
 #endif
 
@@ -38,7 +38,7 @@ Timeout::~Timeout()
 {
 #ifdef _WIN32
     if( m_identifer != 0 ){
-        Glib::Mutex::Lock lock( s_lock );
+        JDLIB::LockGuard lock( s_lock );
         KillTimer( NULL, m_identifer );
         s_timeouts.erase( m_identifer );
         m_identifer = 0;
@@ -53,7 +53,7 @@ Timeout* Timeout::connect( const sigc::slot< bool > slot_timeout, unsigned int i
 {
     Timeout* timeout = new Timeout( slot_timeout );
 #ifdef _WIN32
-    Glib::Mutex::Lock lock( s_lock );
+    JDLIB::LockGuard lock( s_lock );
     // use global windows timer
     UINT_PTR ident = SetTimer( NULL, 0, interval, slot_timeout_win32 );
     if( ident != 0 ) {

--- a/src/jdlib/timeout.h
+++ b/src/jdlib/timeout.h
@@ -7,6 +7,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #undef DELETE // conflict with Gtk::Stock::DELETE
+#include "jdmutex.h"
 #endif
 
 namespace JDLIB
@@ -18,7 +19,7 @@ namespace JDLIB
         Glib::RefPtr<Glib::MainContext> m_context;
         UINT_PTR m_identifer;
         
-        static Glib::StaticMutex s_lock;
+        static JDLIB::StaticMutex s_lock;
         static std::map< UINT_PTR, Timeout* > s_timeouts;
 #else
         sigc::connection m_connection;

--- a/src/winmain.cpp
+++ b/src/winmain.cpp
@@ -39,9 +39,11 @@ JDWinMain::JDWinMain( const bool init, const bool skip_setupdiag,
 
     setlocale( LC_ALL, "ja_JP.UTF-8" );
 
+#ifndef WITH_STD_THREAD
     // GLIBのスレッドシステム初期化
     if( !Glib::thread_supported() ) Glib::thread_init();
     assert( Glib::thread_supported() );
+#endif
 
 #ifndef _WIN32
     // アイコンをセット


### PR DESCRIPTION
現在alphaバージョンであるgtk3版からいくつかのコミットを抽出してリクエストします。gtk3版のブランチは変更量が多すぎるので安定している変更を分けたいと思います。

### 修正の内容

gthreadはglibmmの新しいバージョンで[廃止予定の機能](https://developer.gnome.org/glibmm/2.48/deprecated.html#_deprecated000020)となったため代わりにstd::threadを使うためのオプションを追加する。

* pthreadやgthreadの代わりにstd::threadを使うためのconfigureフラグ`--with-stdthread`を追加（デフォルトではno）。

### 代替案
修正できるが重要ではないもの
* gthreadを使うコードは`Glib::Threads`名前空間 (glibmm 2.47からdeprecated) を参照するように修正する。
* C++11が必須となったので無条件でstd::threadを使うようにする。