### PR TITLE
Fix hash length for git revision information

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,7 +77,7 @@ $(jd_BUILDINFO_HEADER):
 	GIT_STATUS="" ; \
 	if test -n "$(GIT)" ; \
 	then \
-		GIT_HASH=`LANG=C.utf8 "$(GIT)" log --pretty=format:%h -n 1 2>/dev/null`; \
+		GIT_HASH=`LANG=C.utf8 "$(GIT)" log --pretty=format:%h --abbrev=10 -n 1 2>/dev/null`; \
 		GIT_DATE=`LANG=C.utf8 "$(GIT)" log --pretty=format:%ad --date=format:%Y%m%d -n 1 2>/dev/null`; \
 		GIT_STATUS="`LANG=C.utf8 "$(GIT)" status -uno -s 2>/dev/null | head -n 1`" ; \
 		if test -n "$${GIT_HASH}" ; \

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -137,7 +137,9 @@ std::string get_git_revision (const char *git_date, const char *git_hash, const 
 {
 	std::string git_revision = "";
 
-	const size_t max_hash_length = 8;
+	// ハッシュ省略表記はgit 2.11から長さを自動で調整するようになった
+	// ビルドメタデータが表記揺れするのは紛らわしいので固定長にする
+	constexpr const size_t fixed_hash_length = 10;
 	size_t string_length;
 	size_t n;
 
@@ -166,10 +168,10 @@ std::string get_git_revision (const char *git_date, const char *git_hash, const 
 	{
 		hash_valid = true;
 		string_length = strlen(git_hash);
-		if (string_length < max_hash_length) hash_valid = false;
+		if (string_length != fixed_hash_length) hash_valid = false;
 		if (hash_valid)
 		{
-			for (n = 0; n < max_hash_length; n++)
+			for (n = 0; n < fixed_hash_length; n++)
 			{
 				if (! isgraph(git_hash[n]))
 				{
@@ -184,7 +186,7 @@ std::string get_git_revision (const char *git_date, const char *git_hash, const 
 	if (date_valid && hash_valid)
 	{
 		git_revision.append( std::string(git_date) + "(git:");
-		git_revision.append( std::string(git_hash), 0, max_hash_length);
+		git_revision.append( std::string(git_hash), 0, fixed_hash_length);
 		if (git_dirty)
 		{
 			git_revision.append(":M");


### PR DESCRIPTION
ビルドメタデータに表示するコミットハッシュを固定長(10文字)にします。
古いバージョンのgit(< 2.11)では省略表記のデフォルト長が7に固定されているためハッシュを表示できません。
2.11以前のバージョンでもハッシュを表示できるように長さを指定して取得するように変更します。

#### 代替案
* コミットハッシュの長さチェックを省略すれば表示できるが表記ゆれが発生する。
* 余裕を見て10文字取得していますが8文字でも大丈夫かもしれないです。