### PR TITLE
Fix access violation in DBTREE::NodeTreeBase::receive_data()

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1322,6 +1322,7 @@ void NodeTreeBase::receive_data( const char* data, size_t size )
     
     // バッファが '\n' で終わるように調整
     const char* pos = data + size;
+    if( *pos == '\n' && pos != data ) --pos;
     if( *pos == '\0' ) --pos; // '\0' を除く
     while( *pos != '\n' && pos != data ) --pos;
 


### PR DESCRIPTION
## 現象
ある2ch互換板の特定のスレッドのdatを取得した後に
再度同じスレッドを開こうとしたらJDが強制終了しました

当該スレッド: ttp://hosirin.sakura.ne.jp/test/read.cgi/bbs/1536248808/
板のURL: ttp://hosirin.sakura.ne.jp/bbs/
内輪向けの板のためhを省いてます

### 再現用のプロファイル
[jd.tar.gz (展開後約1.5M)](https://github.com/yama-natuki/JD/files/2629303/jd.tar.gz)
SHA256SUM: `3d04fb08728beffc43f4b212472f7d17b32514a5b3b1f0408d11d8d5117f72d1  jd.tar.gz`
当該スレはお気に入りに登録してあります

## 原因
`src/dbtree/nodetreebase.cpp`1323行目以降、`DBTREE:NodeTreeBase::receive_data(const char* data, size_t size)`の関数内で

``` .cpp
// バッファが '\n' で終わるように調整
const char* pos = data + size; // (A)
if( *pos == '\0' ) --pos; // '\0' を除く // (a-1)
while( *pos != '\n' && pos != data ) --pos; // (a-2)

// 前回の残りのデータに新しいデータを付け足して add_raw_lines()にデータを送る
size_t size_in = ( int )( pos - data ); // (B)
if( size_in > 0 ){
    size_in ++; // '\n'を加える // (C)
    memcpy( m_buffer_lines + m_byte_buffer_lines_left , data, size_in );
    m_buffer_lines[ m_byte_buffer_lines_left + size_in ] = '\0';
    add_raw_lines( m_buffer_lines, m_byte_buffer_lines_left + size_in );
}
    
// add_raw_lines() でレジュームに失敗したと判断したら、バッファをクリアする
if( m_resume == RESUME_FAILED ){
    m_byte_buffer_lines_left = 0;
    return;
}

// 残りの分をバッファにコピーしておく
m_byte_buffer_lines_left = size - size_in; // (D)
if( m_byte_buffer_lines_left ) memcpy( m_buffer_lines, data + size_in, m_byte_buffer_lines_left ); // (E)
```
1. (A)の時点で`*pos`の値が`\n`であると
2. (a-1),(a-2)で`pos`が全くデクリメントされないため
3. (B)で`size_in`と`size`の値が等しくなり
4. (C)で`size_in`の値がインクリメントされてしまうと
5. (D)で`size - size_in`がオーバーフローして巨大な整数が`m_byte_buffer_lines_left`に代入されて
6. (E)の`memcpy(..., ..., m_byte_buffer_lines_left)`でアクセス違反を起こします

## 修正内容
(A)の時点で`*pos`の値が'\n'の場合は、必ず1つ手前の文字から検索するように変更しました

## 環境
```
[バージョン] 2.8.9-20181023(git:bb608f24b1:M)
[ディストリ ] Arch Linux (x86_64)
[パッケージ] バイナリ/ソース( <配布元> )
[ DE／WM ] GNOME
[　gtkmm 　] 2.24.5
[　glibmm 　] 2.56.0
[ そ の 他 ] 
```
`autoreconf -i && ./configure && make -j8`でビルドしました。

