### PR TITLE
Replace container type

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1037,7 +1037,7 @@ void CACHE::add_filter_to_diag( Gtk::FileChooserDialog& diag, const int type )
 // multi == true なら複数選択可能
 // 戻り値は選択されたファイルのpathのリスト
 //
-const std::list< std::string > CACHE::open_load_diag( Gtk::Window* parent, const std::string& open_path, const int type, const bool multi )
+std::vector< std::string > CACHE::open_load_diag( Gtk::Window* parent, const std::string& open_path, const int type, const bool multi )
 {
     std::string dir = MISC::get_dir( open_path );
     if( dir.empty() ) dir = MISC::getenv_limited( ENV_HOME, MAX_SAFE_PATH );
@@ -1055,7 +1055,7 @@ const std::list< std::string > CACHE::open_load_diag( Gtk::Window* parent, const
         return MISC::recover_path( diag.get_filenames() );
     }
 
-    return std::list< std::string >();
+    return {};
 }
 
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -8,6 +8,7 @@
 #include <glib.h>
 #include <string>
 #include <list>
+#include <vector>
 #include <ctime>
 
 #ifdef _WIN32
@@ -222,7 +223,7 @@ namespace CACHE
     // open_path はデフォルトの参照先
     // multi == true なら複数選択可能
     // 戻り値は選択されたファイルのpathのリスト
-    const std::list< std::string > open_load_diag( Gtk::Window* parent, const std::string& open_path, const int type, const bool multi );
+    std::vector< std::string > open_load_diag( Gtk::Window* parent, const std::string& open_path, const int type, const bool multi );
 
     // 保存ファイル選択ダイアログを表示する
     std::string open_save_diag( Gtk::Window* parent, const std::string& dir, const std::string& name, const int type );

--- a/src/control/controlutil.cpp
+++ b/src/control/controlutil.cpp
@@ -142,13 +142,12 @@ void CONTROL::set_menu_motion( Gtk::Menu* menu )
 {
     if( !menu ) return;
 
-    Gtk::Menu_Helpers::MenuList& items = menu->items();
-    Gtk::Menu_Helpers::MenuList::iterator it_item = items.begin();
-    for( ; it_item != items.end(); ++it_item ){
+    menu->foreach( []( Gtk::Widget& w ) {
+        auto* const item = dynamic_cast< Gtk::MenuItem* >( &w );
 
         // menuitemの中の名前を読み込んで ID を取得し、CONTROL::Noneでなかったら
         // ラベルを置き換える
-        Gtk::Label* label = dynamic_cast< Gtk::Label* >( (*it_item).get_child() );
+        auto* const label = dynamic_cast< Gtk::Label* >( item->get_child() );
         if( label ){
 #ifdef _DEBUG
             std::cout << label->get_text() << std::endl;
@@ -159,20 +158,20 @@ void CONTROL::set_menu_motion( Gtk::Menu* menu )
                 std::string str_label = CONTROL::get_label_with_mnemonic( id );
                 std::string str_motions = CONTROL::get_str_motions( id );
 
-                ( *it_item ).remove();
+                item->remove();
                 Gtk::Label *label = Gtk::manage( new Gtk::Label( str_label + ( str_motions.empty() ? "" : "  " ), true ) );
                 Gtk::Label *label_motion = Gtk::manage( new Gtk::Label( str_motions ) );
                 Gtk::HBox *box = Gtk::manage( new Gtk::HBox() );
 
                 box->pack_start( *label, Gtk::PACK_SHRINK );
                 box->pack_end( *label_motion, Gtk::PACK_SHRINK );
-                (*it_item).add( *box );
+                item->add( *box );
                 box->show_all();
             }
         }
 
-        if( (*it_item).has_submenu() ) CONTROL::set_menu_motion( (*it_item).get_submenu() );
-    }
+        if( item->has_submenu() ) CONTROL::set_menu_motion( item->get_submenu() );
+    } );
 }
 
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2569,7 +2569,7 @@ void Core::set_command( const COMMAND_ARGS& command )
             if( mdiag.run() != Gtk::RESPONSE_YES ) return;
         }
 
-        std::list< std::string > list_files;
+        std::vector< std::string > list_files;
 
         // ダイアログを開いてファイルのリストを取得
         if( command.arg2.empty() ){
@@ -4271,7 +4271,7 @@ void Core::hide_imagetab()
 //
 // 板にdatファイルをインポートする
 //
-void Core::import_dat( const std::string& url_board, const std::list< std::string > list_files )
+void Core::import_dat( const std::string& url_board, const std::vector< std::string >& list_files )
 {
     if( ! list_files.size() ) return;
 
@@ -4285,10 +4285,7 @@ void Core::import_dat( const std::string& url_board, const std::list< std::strin
     CORE::DATA_INFO info;
     info.type = TYPE_THREAD;
 
-    std::list< std::string >::const_iterator it = list_files.begin();
-    for(; it != list_files.end(); ++it ){
-
-        const std::string& filename = ( *it );
+    for( const auto& filename : list_files ) {
 
 #ifdef _DEBUG
         std::cout << filename << std::endl;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1087,12 +1087,11 @@ void Core::run( const bool init, const bool skip_setupdiag )
     m_menubar->set_size_request( 0 );
 
     // 履歴メニュー追加
-    Gtk::Menu_Helpers::MenuList& items = m_menubar->items();
-    Gtk::Menu_Helpers::MenuList::iterator it_item = items.begin();
-    ++it_item; ++it_item;
-    (*it_item).signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_historymenu ) );
+    const auto items = m_menubar->get_children();
+    auto item = dynamic_cast< Gtk::MenuItem* >( *std::next( items.begin(), 2 ) );
+    item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_historymenu ) );
 
-    Gtk::Menu* submenu = dynamic_cast< Gtk::Menu* >( (*it_item).get_submenu() );
+    Gtk::Menu* submenu = item->get_submenu();
 
     submenu->append( *Gtk::manage( new Gtk::SeparatorMenuItem() ) );
 
@@ -1114,13 +1113,10 @@ void Core::run( const bool init, const bool skip_setupdiag )
     submenu->show_all_children();
 
     // メニューにショートカットキーやマウスジェスチャを表示
-    items = m_menubar->items();
-    it_item = items.begin();
-    for( ; it_item != items.end(); ++it_item ){
-        submenu = dynamic_cast< Gtk::Menu* >( (*it_item).get_submenu() );
-        CONTROL::set_menu_motion( submenu );
-
-        ( *it_item ).signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
+    for( auto&& widget : items ) {
+        auto item = dynamic_cast< Gtk::MenuItem* >( widget );
+        CONTROL::set_menu_motion( item->get_submenu() );
+        item->signal_activate().connect( sigc::mem_fun( *this, &Core::slot_activate_menubar ) );
     }
 
     // ツールバー作成

--- a/src/core.h
+++ b/src/core.h
@@ -221,7 +221,7 @@ namespace CORE
         void hide_imagetab();
 
         // 板にdatファイルをインポートする
-        void import_dat( const std::string& url_board, const std::list< std::string > list_files );
+        void import_dat( const std::string& url_board, const std::vector< std::string >& list_files );
 
         // サイドバー更新チェック
         // open : 更新があったらタブで開く

--- a/src/image/imageviewicon.cpp
+++ b/src/image/imageviewicon.cpp
@@ -176,9 +176,8 @@ Gtk::Menu* ImageViewIcon::get_popupmenu( const std::string& url )
     if( menu ){
 
         // 一番上のitemのラベルを書き換える
-        Gtk::Menu_Helpers::MenuList::iterator it_item =  menu->items().begin();
-
-        Gtk::Label* label = dynamic_cast< Gtk::Label* >( (*it_item).get_child() );
+        auto item = dynamic_cast< Gtk::MenuItem* >( *menu->get_children().begin() );
+        auto label = dynamic_cast< Gtk::Label* >( item->get_child() );
         if( label ) label->set_text_with_mnemonic( ITEM_NAME_GO + std::string( " [ タブ数 " )
                                                    + MISC::itostr( IMAGE::get_admin()->get_tab_nums() ) + " ](_M)" );
     }

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1671,11 +1671,11 @@ const std::string MISC::recover_path( const std::string& str )
 #endif
 }
 
-const std::list< std::string > MISC::recover_path( const std::list< std::string >& list_str )
+std::vector< std::string > MISC::recover_path( std::vector< std::string >&& list_str )
 {
 #ifdef _WIN32
-    std::list< std::string > list_ret;
-    std::list< std::string >::const_iterator it = list_str.begin();
+    std::vector< std::string > list_ret;
+    std::vector< std::string >::const_iterator it = list_str.begin();
     for( ; it != list_str.end() ; ++it )
         list_ret.push_back( MISC::recover_path( *it ) );
     return list_ret;

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -257,7 +257,7 @@ namespace MISC
 
     // pathセパレータを / に置き換える
     const std::string recover_path( const std::string& str );
-    const std::list< std::string > recover_path( const std::list< std::string >& list_str );
+    std::vector< std::string > recover_path( std::vector< std::string >&& list_str );
 
     // 文字列(utf-8)に全角英数字が含まれるか判定する
     const bool has_widechar( const char* str );

--- a/src/message/messageviewbase.cpp
+++ b/src/message/messageviewbase.cpp
@@ -665,12 +665,12 @@ void MessageViewBase::write()
 //
 void MessageViewBase::insert_draft()
 {
-    const std::list< std::string > list_files = CACHE::open_load_diag( MESSAGE::get_admin()->get_win(),
-                                                                       SESSION::get_dir_draft(), CACHE::FILE_TYPE_TEXT, false );
+    const auto list_files = CACHE::open_load_diag( MESSAGE::get_admin()->get_win(),
+                                                   SESSION::get_dir_draft(), CACHE::FILE_TYPE_TEXT, false );
 
     if( list_files.size() )
     {
-        const std::string open_path = *list_files.begin();
+        const std::string& open_path = list_files.front();
         std::string draft;
 
         SESSION::set_dir_draft( MISC::get_dir( open_path ) );

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -47,7 +47,7 @@ AAMenu::~AAMenu()
 
 const int AAMenu::get_size()
 {
-    return items().size();
+    return static_cast< int >( get_children().size() );
 }
 
 
@@ -122,7 +122,7 @@ void AAMenu::on_map()
 #endif
 
     Gtk::Menu::on_map();
-    select_item( items()[ 0 ] );
+    select_item( *dynamic_cast< Gtk::MenuItem* >( *get_children().begin() ) );
 }
 
 
@@ -145,13 +145,17 @@ bool AAMenu::move_down()
     std::cout << "AAMenu::move_down\n";
 #endif
 
-    Gtk::Menu_Helpers::MenuList::iterator it = items().begin();
-    for( ; it != items().end() && &(*it) != m_activeitem; ++it );
+    const auto items = get_children();
+    auto it = std::find( items.begin(), items.end(), static_cast< Gtk::Widget* >( m_activeitem ) );
 
     ++it;
-    if( m_map_items[ &(*it) ] == -1 ) ++it; // セパレータ
-    if( it == items().end() ) it = items().begin(); // 一番下まで行ったら上に戻る
-    select_item( *it );
+    if( m_map_items[ dynamic_cast< Gtk::MenuItem* >( *it ) ] == -1 ) {
+        ++it; // セパレータをスキップする
+    }
+    if( it == items.end() ) {
+        it = items.begin(); // 一番下まで行ったら上に戻る
+    }
+    select_item( *dynamic_cast< Gtk::MenuItem* >( *it ) );
 
     return true;
 }
@@ -164,15 +168,21 @@ bool AAMenu::move_up()
     std::cout << "AAMenu::move_up\n";
 #endif
 
-    Gtk::Menu_Helpers::MenuList::iterator it = items().begin();
-    for( ; it != items().end() && &(*it) != m_activeitem; ++it );
+    // gtk2のGlib::ListHandleのイテレーターはデクリメント不可なので型変換する
+    const std::vector< Gtk::Widget* > items = get_children();
+    auto it = std::find( items.begin(), items.end(), static_cast< Gtk::Widget* >( m_activeitem ) );
 
-    if( it != items().begin() ){ 
+    if( it != items.begin() ) {
         --it;
-        if( m_map_items[ &(*it) ] == -1 && it != items().begin() ) --it;  // セパレータ
-        select_item( *it );
+        if( m_map_items[ dynamic_cast< Gtk::MenuItem* >( *it ) ] == -1 && it != items.begin() ) {
+            --it; // セパレータをスキップする
+        }
+        select_item( *dynamic_cast< Gtk::MenuItem* >( *it ) );
     }
-    else select_item( items().back() ); // 一番上に行ったら下に戻る
+    else {
+        // 一番上に行ったら下に戻る
+        select_item( *dynamic_cast< Gtk::MenuItem* >( items.back() ) );
+    }
 
     return true;
 }


### PR DESCRIPTION
子ウィジェットを扱うコンテナ型を変更しgtk2/3で共通のコードになるように修正します。

gtk2サポートの最小バージョンを引き上げたりgtkmm2/3の違いを避けてC APIを使うなど共通化できるコードは一応ありますがアグレッシブ＆重箱の隅をつつく変更になるので予定してません。