### PR TITLE
Use flag pedantic errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ dnl ユーザー設定
 dnl
 
 dnl 追加コンパイルオプション
-CXXFLAGS="$CXXFLAGS -ggdb -Wall"
+CXXFLAGS="-ggdb -Wall -pedantic-errors $CXXFLAGS"
 
 dnl ---------------------------------------------------
 dnl ---------------------------------------------------

--- a/src/bbslist/bbslistview.h
+++ b/src/bbslist/bbslistview.h
@@ -34,7 +34,7 @@ namespace BBSLIST
 
         virtual void delete_view_impl();
     };
-};
+}
 
 
 #endif

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -21,7 +21,7 @@
 namespace SKELETON
 {
     class Admin;
-};
+}
 
 
 #define SUBDIR_ETCLIST "外部板"
@@ -323,7 +323,7 @@ namespace BBSLIST
         // ツリーの編集ウィンドウが閉じた
         void slot_hide_editlistwin();
     };
-};
+}
 
 
 #endif

--- a/src/bbslist/editlistwin.h
+++ b/src/bbslist/editlistwin.h
@@ -46,6 +46,6 @@ namespace BBSLIST
         void slot_redo();
         void slot_undo_buffer_changed();
     };
-};
+}
 
 #endif

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -48,7 +48,7 @@ namespace BBSLIST
         void slot_show_tree();
         virtual void timeout();
     };
-};
+}
 
 
 #endif

--- a/src/bbslist/selectlistview.h
+++ b/src/bbslist/selectlistview.h
@@ -40,7 +40,7 @@ namespace BBSLIST
         virtual Gtk::Menu* get_popupmenu( const std::string& url );
     };
 
-};
+}
 
 
 #endif

--- a/src/board/boardview.h
+++ b/src/board/boardview.h
@@ -28,6 +28,6 @@ namespace BOARD
         virtual void update_view();
         virtual void update_boardname();
     };
-};
+}
 
 #endif

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -300,7 +300,7 @@ namespace BOARD
         void draw_bg_articles();
     };
 
-};
+}
 
 
 #endif

--- a/src/board/boardviewlog.h
+++ b/src/board/boardviewlog.h
@@ -48,6 +48,6 @@ namespace BOARD
         virtual void save_column_width(){} // 保存しない
     };
 
-};
+}
 
 #endif

--- a/src/board/boardviewnext.h
+++ b/src/board/boardviewnext.h
@@ -60,6 +60,6 @@ namespace BOARD
         virtual void save_column_width(){} // 保存しない
     };
 
-};
+}
 
 #endif

--- a/src/board/boardviewsidebar.h
+++ b/src/board/boardviewsidebar.h
@@ -51,6 +51,6 @@ namespace BOARD
         virtual void save_column_width(){} // 保存しない
     };
 
-};
+}
 
 #endif

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -18,7 +18,7 @@
 namespace XML
 {
     class Document;
-};
+}
 
 namespace DBTREE
 {

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2540,9 +2540,9 @@ const bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
             // utf-8で"＞"
             else if( ( unsigned char )( *pos ) == 0xef && ( unsigned char ) ( *( pos + 1 ) ) == 0xbc
                      && ( unsigned char ) ( *( pos + 2 ) ) == 0x9e ){
-                tmp_out[ lng_out++ ] = 0xef;
-                tmp_out[ lng_out++ ] = 0xbc;
-                tmp_out[ lng_out++ ] = 0x9e;
+                tmp_out[ lng_out++ ] = static_cast< char >( 0xef );
+                tmp_out[ lng_out++ ] = static_cast< char >( 0xbc );
+                tmp_out[ lng_out++ ] = static_cast< char >( 0x9e );
                 pos += 3;
             }
             else if( i == 0 ) return false;
@@ -2567,9 +2567,9 @@ const bool NodeTreeBase::check_anchor( const int mode, const char* str_in,
         else if( ( unsigned char )( *pos ) == 0xe3 && ( unsigned char ) ( *( pos + 1 ) ) == 0x80
                  && ( unsigned char ) ( *( pos + 2 ) ) == 0x81 ){
 
-            tmp_out[ lng_out++ ] = 0xe3;
-            tmp_out[ lng_out++ ] = 0x80;
-            tmp_out[ lng_out++ ] = 0x81;
+            tmp_out[ lng_out++ ] = static_cast< char >( 0xe3 );
+            tmp_out[ lng_out++ ] = static_cast< char >( 0x80 );
+            tmp_out[ lng_out++ ] = static_cast< char >( 0x81 );
 
             str_link[ 0 ] = ',';
             ++str_link;

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -220,7 +220,7 @@ std::string ENVIRONMENT::get_jdversion()
     jd_version << MAJORVERSION << "."
                 << MINORVERSION << "."
                 << MICROVERSION << "-"
-                << JDTAG << get_git_revision(GIT_DATE, GIT_HASH, GIT_DIRTY, JDDATE);
+                << JDTAG << get_git_revision(GIT_DATE, GIT_HASH, GIT_DIRTY, JDDATE_FALLBACK);
 #endif // JDVERSION_SVN
 
     return jd_version.str();

--- a/src/history/historymanager.h
+++ b/src/history/historymanager.h
@@ -15,7 +15,7 @@ namespace Gtk
 {
     class Menu;
     class MenuItem;
-};
+}
 
 
 namespace HISTORY

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -124,7 +124,7 @@ namespace IMAGE
 
     IMAGE::ImageAdmin* get_admin();
     void delete_admin();
-};
+}
 
 
 #endif

--- a/src/jdlib/jdiconv.cpp
+++ b/src/jdlib/jdiconv.cpp
@@ -145,8 +145,8 @@ const char* Iconv::convert( char* str_in, int size_in, int& size_out )
                     if( ( code0 >= 0x81 && code0 <=0x9F )
                         || ( code0 >= 0xe0 && code0 <=0xef ) ){
 
-                        *m_buf_in_tmp = 0x81;
-                        *(m_buf_in_tmp+1) = 0xa0;
+                        *m_buf_in_tmp = static_cast< char >( 0x81 );
+                        *(m_buf_in_tmp+1) = static_cast< char >( 0xa0 );
 
 #ifdef _DEBUG_ICONV
                         snprintf( str_tmp, 256, "iconv 0x%x%x -> □ (0x81a0) ", code0, code1 );

--- a/src/jdlib/jdthread.cpp
+++ b/src/jdlib/jdthread.cpp
@@ -15,6 +15,18 @@
 using namespace JDLIB;
 
 
+#ifdef _DEBUG
+#ifdef WITH_STD_THREAD
+template < class CharT, class Traits >
+static std::basic_ostream< CharT, Traits >&
+operator<<( std::basic_ostream< CharT, Traits >& ost, const std::thread& pth )
+{
+    return ost << pth.get_id();
+}
+#endif // WITH_STD_THREAD
+#endif // _DEBUG
+
+
 Thread::Thread()
 {
     JDTH_CLEAR( m_thread );

--- a/src/jdlib/loader.h
+++ b/src/jdlib/loader.h
@@ -59,8 +59,8 @@ namespace JDLIB
         char* m_buf;
 
         // zlib 用のバッファ
-        unsigned long m_lng_buf_zlib_in; 
-        unsigned long m_lng_buf_zlib_out;; 
+        unsigned long m_lng_buf_zlib_in;
+        unsigned long m_lng_buf_zlib_out;
         Bytef* m_buf_zlib_in;
         Bytef* m_buf_zlib_out;
 

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -51,20 +51,20 @@ const std::string create_sha1( const std::string& key )
 
 #ifdef USE_OPENSSL
 
-    const unsigned int digest_length = SHA_DIGEST_LENGTH;
+    constexpr const unsigned int digest_length = SHA_DIGEST_LENGTH;
 
-    unsigned char digest[ digest_length ];
+    std::array< unsigned char, digest_length > digest;
 
     // unsigned char *SHA1( const unsigned char *, size_t, unsigned char * );
-    SHA1( (const unsigned char *)key.c_str(), key.length(), digest );
+    SHA1( (const unsigned char *)key.c_str(), key.length(), digest.data() );
 
 #else // defined USE_GNUTLS
 
     const unsigned int digest_length = gcry_md_get_algo_dlen( GCRY_MD_SHA1 );
 
-    unsigned char digest[ digest_length ];
+    std::vector< unsigned char > digest( digest_length );
 
-    gcry_md_hash_buffer( GCRY_MD_SHA1, digest, key.c_str(), key.length() );
+    gcry_md_hash_buffer( GCRY_MD_SHA1, digest.data(), key.c_str(), key.length() );
 
 #endif
 

--- a/src/jdlib/misctrip.h
+++ b/src/jdlib/misctrip.h
@@ -11,6 +11,6 @@ namespace MISC
 {
     // トリップを取得 (SHA1等の新方式対応)
     const std::string get_trip( const std::string& str, const std::string& charset );
-};
+}
 
 #endif

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1060,8 +1060,7 @@ const std::string MISC::url_decode( const std::string& url )
 
     const size_t url_length = url.length();
 
-    char decoded[ url_length + 1 ];
-    memset( decoded, 0, sizeof( decoded ) );
+    std::vector< char > decoded( url_length + 1, '\0' );
 
     unsigned int a, b;
     for( a = 0, b = a; a < url_length; ++a, ++b )
@@ -1093,7 +1092,7 @@ const std::string MISC::url_decode( const std::string& url )
         }
     }
 
-    return std::string( decoded );
+    return decoded.data();
 }
 
 
@@ -1124,7 +1123,7 @@ const std::string MISC::url_encode( const char* str, const size_t n )
             ( c != '@' ) &&
             ( c != '_' )){
 
-            snprintf( str_tmp, tmplng , "\%%%02x", c );
+            snprintf( str_tmp, tmplng , "%%%02x", c );
         }
         else {
             str_tmp[ 0 ] = c;
@@ -1641,15 +1640,13 @@ const std::string MISC::getenv_limited( const char *name, const size_t size )
 {
     if( ! name || ! getenv( name ) ) return std::string();
 
-    char env[ size + 1 ];
-    env[ size ] = '\0';
-
-    strncpy( env, getenv( name ), size );
+    std::vector< char > env( size + 1, '\0' );
+    strncpy( env.data(), getenv( name ), size );
 
 #ifdef _WIN32
-    return recover_path( Glib::locale_to_utf8( std::string( env ) ) );
+    return recover_path( Glib::locale_to_utf8( std::string( env.data() ) );
 #else
-    return std::string( env );
+    return env.data();
 #endif
 }
 

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -13,16 +13,20 @@
 // svn 版の時は JDVERSION_SVN をdefineする
 //#define JDVERSION_SVN
 
+// gitのリポジトリを使ってビルドしているときはリビジョンから日付を取得する
+// リビジョンが参照できない場合はJDDATE_FALLBACKを使う
+// SEE ALSO: ENVIRONMENT::get_jdversion()
+
 #define MAJORVERSION 2
 #define MINORVERSION 8
 #define MICROVERSION 9
-#define JDDATE    "180424"
+#define JDDATE_FALLBACK    "180424"
 #define JDTAG     ""
 
 //---------------------------------
 
 #define JDVERSION ( MAJORVERSION * 100 + MINORVERSION * 10 + MICROVERSION )
-#define JDVERSION_FULL ( JDVERSION * 1000000 + atoi( JDDATE ) )
+#define JDVERSION_FULL ( JDVERSION * 1000000 + atoi( JDDATE_FALLBACK ) )
 
 //---------------------------------
 
@@ -76,7 +80,7 @@
 #define JDRC_VERSION_FMT(a,b,c,d,e) #a "." #b "." #c "-" d e
 #endif
 #define JDRC_VERSION_STR JDRC_VERSION_EXP( \
-            MAJORVERSION, MINORVERSION, MICROVERSION, JDTAG, JDDATE)
+            MAJORVERSION, MINORVERSION, MICROVERSION, JDTAG, JDDATE_FALLBACK)
 
 #define JDRC_FILEVERSION        JDRC_VERSION_STR
 #define JDRC_PRODUCTVERSION     JDRC_FILEVERSION

--- a/src/openurldiag.h
+++ b/src/openurldiag.h
@@ -25,7 +25,7 @@ namespace CORE
 
         virtual void slot_ok_clicked();
     };
-};
+}
 
 
 #endif

--- a/src/session.h
+++ b/src/session.h
@@ -16,7 +16,7 @@
 namespace ARTICLE
 {
     class DrawAreaBase;
-};
+}
 
 namespace SESSION
 {

--- a/src/skeleton/msgdiag.cpp
+++ b/src/skeleton/msgdiag.cpp
@@ -217,4 +217,4 @@ MsgOverwriteDiag::MsgOverwriteDiag( Gtk::Window* parent )
     add_button( "上書き", OVERWRITE_YES );
     add_button( "すべていいえ", OVERWRITE_NO_ALL );
     add_button( "すべて上書き", OVERWRITE_YES_ALL );
-};
+}


### PR DESCRIPTION
gcc以外のコンパイラにも対応しやすくするためにオプション`-pedantic-errors`を追加してコンパイラの拡張機能を禁止します。修正の詳細は b46e404 を見てください。

その他
* gitのリポジトリでビルドしているときはマクロを使わずgitのリビジョンから日付を取得することを`jdversion.h`に説明コメントを追加する。またマクロの名前を`JDDATE`から`JDDATE_FALLBACK`に変更する。 ( 405da09 )
* std::threadのデバッグ用コードが壊れていたのを修正する。 ( 69da80e  )