### PR TITLE
Use compiler option "-pedantic" instead of "-pedantic-errors"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ dnl ユーザー設定
 dnl
 
 dnl 追加コンパイルオプション
-CXXFLAGS="-ggdb -Wall -pedantic-errors $CXXFLAGS"
+CXXFLAGS="-ggdb -Wall -pedantic $CXXFLAGS"
 
 dnl ---------------------------------------------------
 dnl ---------------------------------------------------


### PR DESCRIPTION
ライブラリヘッダーのエラーを避けるためコンパイラの拡張機能は警告にする
https://github.com/yama-natuki/JD/pull/20#issuecomment-449643098