### PR TITLE
Use override keyword

### DIFF
--- a/src/article/articleadmin.h
+++ b/src/article/articleadmin.h
@@ -36,27 +36,27 @@ namespace ARTICLE
         ArticleAdmin( const std::string& url );
         ~ArticleAdmin();
 
-        virtual void save_session();
+        void save_session() override;
        
       protected:
-        virtual COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list );
-        virtual SKELETON::View* create_view( const COMMAND_ARGS& command );
+        COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list ) override;
+        SKELETON::View* create_view( const COMMAND_ARGS& command ) override;
 
         // ツールバー
-        virtual void show_toolbar();
-        virtual void toggle_toolbar();
-        virtual void open_searchbar();
-        virtual void close_searchbar();
+        void show_toolbar() override;
+        void toggle_toolbar() override;
+        void open_searchbar() override;
+        void close_searchbar() override;
 
-        virtual void command_local( const COMMAND_ARGS& command );
+        void command_local( const COMMAND_ARGS& command ) override;
 
-        virtual void restore( const bool only_locked );
-        virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock );
-        virtual const std::string command_to_url( const COMMAND_ARGS& command );
+        void restore( const bool only_locked ) override;
+        COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
+        const std::string command_to_url( const COMMAND_ARGS& command ) override;
 
-        virtual void switch_admin();
+        void switch_admin() override;
 
-        virtual void restore_lasttab();
+        void restore_lasttab() override;
 
       private:
 
@@ -66,7 +66,7 @@ namespace ARTICLE
         void delete_all_popups();
 
         // タブをお気に入りにドロップした時にお気に入りがデータ送信を要求してきた
-        virtual void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page );
+        void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override;
     };
     
     ARTICLE::ArticleAdmin* get_admin();

--- a/src/article/articleview.h
+++ b/src/article/articleview.h
@@ -36,35 +36,35 @@ namespace ARTICLE
         ArticleViewMain( const std::string& url );
         ~ArticleViewMain();
 
-        virtual void clock_in();
-        virtual void clock_in_always();
+        void clock_in() override;
+        void clock_in_always() override;
 
-        virtual void goto_num( const int num_to, const int num_from );
+        void goto_num( const int num_to, const int num_from ) override;
 
         // SKELETON::View の関数のオーバロード
 
-        virtual void save_session();
+        void save_session() override;
 
-        virtual const bool is_loading() const;
-        virtual const bool is_updated();
-        virtual const bool is_check_update();
-        virtual const bool is_old();
-        virtual const bool is_broken();
+        const bool is_loading() const override;
+        const bool is_updated() override;
+        const bool is_check_update() override;
+        const bool is_old() override;
+        const bool is_broken() override;
 
-        virtual void show_view();
-        virtual void update_view();
-        virtual void update_finish();
-        virtual void relayout();
+        void show_view() override;
+        void update_view() override;
+        void update_finish() override;
+        void relayout() override;
 
       protected:
 
         // 実況
-        virtual void live_start();
-        virtual void live_stop();
+        void live_start() override;
+        void live_stop() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
 
         // ステータスに表示する文字列作成
         void create_status_message();

--- a/src/article/articleviewbase.h
+++ b/src/article/articleviewbase.h
@@ -92,7 +92,7 @@ namespace ARTICLE
     public:
 
         ArticleViewBase( const std::string& url, const std::string& url_article );
-        virtual ~ArticleViewBase();
+        ~ArticleViewBase();
 
         const std::string& url_article() const { return m_url_article; }
 
@@ -100,47 +100,46 @@ namespace ARTICLE
 
         // SKELETON::View の関数のオーバロード
 
-        virtual void save_session(){}        
+        void save_session() override {}
 
-        virtual const std::string url_for_copy(); // コピーやURLバー表示用のURL
-        virtual const int width_client();
-        virtual const int height_client();
-        virtual const int get_icon( const std::string& iconname );
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const std::string url_for_copy() override; // コピーやURLバー表示用のURL
+        const int width_client() override;
+        const int height_client() override;
+        const int get_icon( const std::string& iconname ) override;
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
-        virtual void clock_in();
+        void clock_in() override;
         void clock_in_smooth_scroll();
 
         // キーを押した
-        virtual const bool slot_key_press( GdkEventKey* event );
+        const bool slot_key_press( GdkEventKey* event ) override;
 
-        virtual void write();
-        virtual void reload();
-        virtual void stop();
-        virtual void redraw_view();
-        virtual void focus_view();
-        virtual void focus_out();
-        virtual void close_view();
-        virtual void delete_view();
-        virtual void set_favorite();
-        virtual const bool operate_view( const int control );
-        virtual void goto_top();
-        virtual void goto_bottom();
-        virtual void goto_num( const int num_to, const int num_from );
-        virtual void show_preference();
+        void write() override;
+        void reload() override;
+        void stop() override;
+        void redraw_view() override;
+        void focus_view() override;
+        void focus_out() override;
+        void close_view() override;
+        void delete_view() override;
+        void set_favorite() override;
+        const bool operate_view( const int control ) override;
+        void goto_top() override;
+        void goto_bottom() override;
+        void goto_num( const int num_to, const int num_from ) override;
+        void show_preference() override;
 
         // 進む、戻る
-        virtual void back_viewhistory( const int count );
-        virtual void forward_viewhistory( const int count );
+        void back_viewhistory( const int count ) override;
+        void forward_viewhistory( const int count ) override;
  
         // 検索
-        virtual void exec_search();
-        virtual void up_search();
-        virtual void down_search();
-        virtual void operate_search( const std::string& controlid );
+        void exec_search() override;
+        void up_search() override;
+        void down_search() override;
+        void operate_search( const std::string& controlid ) override;
         void clear_highlight();  // ハイライト解除
 
         // 記事削除 & 再オープン
@@ -157,15 +156,15 @@ namespace ARTICLE
     protected:
 
         // Viewが所属するAdminクラス
-        virtual SKELETON::Admin* get_admin();
+        SKELETON::Admin* get_admin() override;
 
         const JDLIB::RefPtr_Lock< DBTREE::ArticleBase >& get_article() const noexcept;
 
         // ポップアップメニューを表示する前にメニューのアクティブ状態を切り替える
-        virtual void activate_act_before_popupmenu( const std::string& url );
+        void activate_act_before_popupmenu( const std::string& url ) override;
 
         // ポップアップメニュー取得
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
 
         // レスポップアップを隠す
         void hide_popup( const bool force = false );
@@ -237,12 +236,12 @@ namespace ARTICLE
         // 実況用
         void set_enable_live( const bool enable ){ m_enable_live = enable; }
         void set_live( const bool live );
-        virtual void live_start(){}
-        virtual void live_stop(){}
+        virtual void live_start() {}
+        virtual void live_stop() {}
 
     private:
 
-        virtual DrawAreaBase* create_drawarea();        
+        virtual DrawAreaBase* create_drawarea();
 
         void setup_action();
 

--- a/src/article/articleviewetc.h
+++ b/src/article/articleviewetc.h
@@ -22,14 +22,14 @@ namespace ARTICLE
         ~ArticleViewRes();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -46,14 +46,14 @@ namespace ARTICLE
         ~ArticleViewName();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -70,14 +70,14 @@ namespace ARTICLE
         ~ArticleViewID();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -94,14 +94,14 @@ namespace ARTICLE
         ~ArticleViewBM();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -119,14 +119,14 @@ namespace ARTICLE
         ~ArticleViewPost();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -142,14 +142,14 @@ namespace ARTICLE
         ~ArticleViewURL();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -166,14 +166,14 @@ namespace ARTICLE
         ~ArticleViewRefer();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
 
@@ -192,14 +192,14 @@ namespace ARTICLE
         ~ArticleViewDrawout();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
+        void relayout() override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 
     /////////////////////////////////////////////////////////////////////////
@@ -215,17 +215,17 @@ namespace ARTICLE
         ~ArticleViewPostlog();
 
         // SKELETON::View の関数のオーバロード
-        virtual void relayout();
-        virtual void stop(){} // キャンセル
+        void relayout() override;
+        void stop() override {} // キャンセル
 
         // 検索
-        virtual void operate_search( const std::string& controlid );
+        void operate_search( const std::string& controlid ) override;
 
-        virtual void show_view();
-        virtual void reload();
+        void show_view() override;
+        void reload() override;
 
       private:
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 }
 

--- a/src/article/articleviewinfo.h
+++ b/src/article/articleviewinfo.h
@@ -17,22 +17,22 @@ namespace ARTICLE
         ~ArticleViewInfo();
 
         // viewの操作をキャンセル
-        virtual const bool operate_view( const int control ){ return false; }
+        const bool operate_view( const int control ) override { return false; }
 
       protected:
 
         // ポップアップメニューは表示しない
-        virtual Gtk::Menu* get_popupmenu( const std::string& url ){ return NULL; }
+        Gtk::Menu* get_popupmenu( const std::string& url ) override { return NULL; }
 
       private:
 
         // ボタンプレスキャンセル
-        virtual bool slot_button_press( std::string url, int res_number, GdkEventButton* event ){ return true; }
+        bool slot_button_press( std::string url, int res_number, GdkEventButton* event ) override { return true; }
 
         // ポップアップ表示キャンセル
-        virtual void slot_on_url( std::string url, std::string imgurl, int res_number ) {}
+        void slot_on_url( std::string url, std::string imgurl, int res_number ) override {}
 
-        virtual DrawAreaBase* create_drawarea();
+        DrawAreaBase* create_drawarea() override;
     };
 }
 

--- a/src/article/articleviewpopup.h
+++ b/src/article/articleviewpopup.h
@@ -19,16 +19,16 @@ namespace ARTICLE
 
       public:
         ArticleViewPopup( const std::string& url, bool show_abone );
-        virtual ~ArticleViewPopup();
+        ~ArticleViewPopup();
 
-        virtual void stop(){}
+        void stop() override {}
 
       protected:
         void show_instruct_popup();
         const bool show_abone() const { return m_show_abone; }
 
       private:
-        virtual DrawAreaBase* create_drawarea();
+        DrawAreaBase* create_drawarea() override;
     };
 
     /////////////////////////////////////////////////////////////////////////
@@ -41,9 +41,9 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupHTML( const std::string& url, const std::string& html ): ArticleViewPopup( url, false ), m_html( html ){}
-        virtual ~ArticleViewPopupHTML(){}
+        ~ArticleViewPopupHTML() noexcept {}
 
-        virtual void show_view(){ append_html( m_html ); }
+        void show_view() override { append_html( m_html ); }
     };
 
 
@@ -59,9 +59,10 @@ namespace ARTICLE
       public:
         ArticleViewPopupRes( const std::string& url, const std::string& num, bool show_title, bool show_abone )
         : ArticleViewPopup( url, show_abone ), m_str_num( num ), m_show_title( show_title ){}
-        virtual ~ArticleViewPopupRes(){}
+        ~ArticleViewPopupRes() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             show_res( m_str_num, m_show_title );
         }
@@ -78,9 +79,10 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupName( const std::string& url, const std::string& name ): ArticleViewPopup( url, false ), m_str_name( name ){}
-        virtual ~ArticleViewPopupName(){}
+        ~ArticleViewPopupName() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             show_name( m_str_name, false );
         }
@@ -97,9 +99,10 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupID( const std::string& url, const std::string& id ): ArticleViewPopup( url, false ), m_str_id( id ) {}
-        virtual ~ArticleViewPopupID(){}
+        ~ArticleViewPopupID() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             show_id( m_str_id, false );
         }
@@ -116,9 +119,10 @@ namespace ARTICLE
 
       public:
         ArticleViewPopupRefer( const std::string& url, const std::string& num ): ArticleViewPopup( url, false ), m_str_num( num ){}
-        virtual ~ArticleViewPopupRefer(){}
+        ~ArticleViewPopupRefer() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             show_refer( atol( m_str_num.c_str() ) );
         }
@@ -135,9 +139,10 @@ namespace ARTICLE
       public:
         ArticleViewPopupDrawout( const std::string& url, const std::string& query, bool mode_or )
         : ArticleViewPopup( url, false ), m_query( query ), m_mode_or( mode_or ){}
-        virtual ~ArticleViewPopupDrawout(){}
+        ~ArticleViewPopupDrawout() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             drawout_keywords( m_query, m_mode_or, false );
         }
@@ -151,9 +156,10 @@ namespace ARTICLE
     {
       public:
       ArticleViewPopupBM( const std::string& url ) : ArticleViewPopup( url, false ){}
-        virtual ~ArticleViewPopupBM(){}
+        ~ArticleViewPopupBM() noexcept {}
 
-        virtual void show_view(){
+        void show_view() override
+        {
             show_instruct_popup();
             show_bm();
         }

--- a/src/article/articleviewpreview.h
+++ b/src/article/articleviewpreview.h
@@ -18,13 +18,13 @@ namespace ARTICLE
         ArticleViewPreview( const std::string& url );
         ~ArticleViewPreview();
 
-        virtual const bool operate_view( const int control );
+        const bool operate_view( const int control ) override;
 
       private:
 
-        virtual bool slot_button_press( std::string url, int res_number, GdkEventButton* event );
+        bool slot_button_press( std::string url, int res_number, GdkEventButton* event ) override;
 
-        virtual void goto_num( const int num_to, const int num_from ){}
+        void goto_num( const int num_to, const int num_from ) override {}
     };
 }
 

--- a/src/article/articleviewsearch.h
+++ b/src/article/articleviewsearch.h
@@ -35,30 +35,29 @@ namespace ARTICLE
 
         // SKELETON::View の関数のオーバロード
 
-        virtual const std::string url_for_copy(); // コピーやURLバー表示用のURL
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const std::string url_for_copy() override; // コピーやURLバー表示用のURL
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
-        virtual const bool is_loading() const { return m_loading; }
+        const bool is_loading() const override { return m_loading; }
 
-        virtual void focus_view();
-        virtual void show_view();
-        virtual void relayout();
-        virtual void reload();
-        virtual void stop();
+        void focus_view() override;
+        void show_view() override;
+        void relayout() override;
+        void reload() override;
+        void stop() override;
 
         // 検索
-        virtual void exec_search();
-        virtual void operate_search( const std::string& controlid );
+        void exec_search() override;
+        void operate_search( const std::string& controlid ) override;
         const bool get_enable_bm() const{ return m_enable_bm; }
         const bool get_bm() const { return m_bm; }
         void set_bm( const bool set ){ m_bm = set; }
 
       protected:
 
-        virtual void slot_push_write(){} // 書き込みキャンセル
+        virtual void slot_push_write() {} // 書き込みキャンセル
 
       private:
 
@@ -76,7 +75,7 @@ namespace ARTICLE
 
         void slot_search_fin( const std::string& id );
 
-        virtual void exec_reload();
+        void exec_reload() override;
     };
 }
 

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -227,7 +227,7 @@ namespace ARTICLE
         SIG_LEAVE_URL sig_leave_url(){ return m_sig_leave_url; }
 
         DrawAreaBase( const std::string& url );
-        virtual ~DrawAreaBase();
+        ~DrawAreaBase();
 
         const std::string& get_url() const { return m_url; }
         const int& width_client() const { return m_width_client; }

--- a/src/article/drawareapopup.h
+++ b/src/article/drawareapopup.h
@@ -20,10 +20,10 @@ namespace ARTICLE
       protected:
 
         // レイアウト実行
-        virtual bool exec_layout();
+        bool exec_layout() override;
 
         // リサイズした
-        virtual bool slot_configure_event( GdkEventConfigure* event );
+        bool slot_configure_event( GdkEventConfigure* event ) override;
     };
 }
 

--- a/src/article/embeddedimage.h
+++ b/src/article/embeddedimage.h
@@ -43,7 +43,7 @@ namespace ARTICLE
       private:
         void stop();
         void wait();
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
     };
 }
 

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -212,7 +212,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     if( command == "show_abone" ) m_notebook.set_current_page( page_abone );
 }
 
-Preferences::~Preferences()
+Preferences::~Preferences() noexcept
 {}
 
 

--- a/src/article/preference.h
+++ b/src/article/preference.h
@@ -64,10 +64,10 @@ namespace ARTICLE
       public:
 
         Preferences( Gtk::Window* parent, const std::string& url, const std::string command );
-        virtual ~Preferences();
+        ~Preferences() noexcept;
 
       private:
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
         void slot_clear_modified();
         void slot_clear_post_history();
     };

--- a/src/article/toolbar.h
+++ b/src/article/toolbar.h
@@ -33,14 +33,14 @@ namespace ARTICLE
       public:
 
         ArticleToolBar(); 
-        virtual ~ArticleToolBar(){}
+        ~ArticleToolBar() noexcept {}
 
         // タブが切り替わった時に呼び出される( Viewの情報を取得する )
-        virtual void set_view( SKELETON::View * view );
+        void set_view( SKELETON::View * view ) override;
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
 
         // ボタンを押したときのslot関数
         void slot_open_board();

--- a/src/article/toolbarsearch.h
+++ b/src/article/toolbarsearch.h
@@ -26,14 +26,14 @@ namespace ARTICLE
       public:
 
         SearchToolBar();
-        virtual ~SearchToolBar(){}
+        ~SearchToolBar() noexcept {}
 
         // タブが切り替わった時に呼び出される( Viewの情報を取得する )
-        virtual void set_view( SKELETON::View * view );
+        void set_view( SKELETON::View * view ) override;
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
 
       private:
 

--- a/src/article/toolbarsimple.h
+++ b/src/article/toolbarsimple.h
@@ -14,11 +14,11 @@ namespace ARTICLE
       public:
 
         ArticleToolBarSimple();
-        virtual ~ArticleToolBarSimple(){}
+        ~ArticleToolBarSimple() noexcept {}
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
     };
 }
 

--- a/src/articleitemmenupref.h
+++ b/src/articleitemmenupref.h
@@ -14,16 +14,16 @@ namespace CORE
       public:
 
         ArticleItemMenuPref( Gtk::Window* parent, const std::string& url );
-        virtual ~ArticleItemMenuPref(){}
+        ~ArticleItemMenuPref() noexcept {}
 
       private:
 
         // OKボタン
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/articleitempref.h
+++ b/src/articleitempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         ArticleItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~ArticleItemPref(){}
+        ~ArticleItemPref() noexcept {}
 
       private:
 
         // OKボタン
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/bbslist/bbslistadmin.h
+++ b/src/bbslist/bbslistadmin.h
@@ -32,7 +32,7 @@ namespace BBSLIST
         BBSListAdmin( const std::string& url );
         ~BBSListAdmin();
 
-        virtual void save_session();
+        void save_session() override;
         
         // 履歴を DATA_INFO_LIST 型で取得
         void get_history( const std::string& url, CORE::DATA_INFO_LIST& info_list );
@@ -45,28 +45,28 @@ namespace BBSLIST
 
       protected:
 
-        SKELETON::View* create_view( const COMMAND_ARGS& command );
+        SKELETON::View* create_view( const COMMAND_ARGS& command ) override;
 
         // ツールバー
-        virtual void show_toolbar();
-        virtual void toggle_toolbar();
+        void show_toolbar() override;
+        void toggle_toolbar() override;
 
-        virtual void command_local( const COMMAND_ARGS& command );
+        void command_local( const COMMAND_ARGS& command ) override;
 
-        virtual void restore( const bool only_locked );
-        virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock );
+        void restore( const bool only_locked ) override;
+        COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
 
-        virtual void switch_admin();
+        void switch_admin() override;
 
         // bbslistはクローズしない
-        virtual void close_view( const std::string& url ){}
-        virtual void close_all_view( const std::string& url ){}
+        void close_view( const std::string& url ) override {}
+        void close_all_view( const std::string& url ) override {}
 
         // タブの D&D 処理をしない
-        virtual void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ){}
+        void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override {}
 
         // タブメニュー表示キャンセル
-        virtual void slot_tab_menu( int page, int x, int y ){}
+        void slot_tab_menu( int page, int x, int y ) override {}
     };
 
     

--- a/src/bbslist/bbslistview.h
+++ b/src/bbslist/bbslistview.h
@@ -16,23 +16,23 @@ namespace BBSLIST
     {
       public:
         BBSListViewMain( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
-        virtual ~BBSListViewMain();
+        ~BBSListViewMain();
 
-        virtual void show_view();
-        virtual void update_view();
-        virtual void delete_view();
-        virtual void show_preference();
+        void show_view() override;
+        void update_view() override;
+        void delete_view() override;
+        void show_preference() override;
 
       protected:
 
         // xml保存
-        virtual void save_xml();
+        void save_xml() override;
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
 
       private:
 
-        virtual void delete_view_impl();
+        void delete_view_impl() override;
     };
 }
 

--- a/src/bbslist/bbslistviewbase.h
+++ b/src/bbslist/bbslistviewbase.h
@@ -87,7 +87,7 @@ namespace BBSLIST
       protected:
 
         // Viewが所属するAdminクラス
-        virtual SKELETON::Admin* get_admin();
+        SKELETON::Admin* get_admin() override;
 
         // treeviewのD&Dによる編集を可能にする
         void set_editable( const bool editable );
@@ -106,7 +106,7 @@ namespace BBSLIST
         const bool& get_ready_tree() const{ return m_ready_tree; }
         void set_open_only_onedir( const bool set ){ m_open_only_onedir = set; }
 
-        virtual void activate_act_before_popupmenu( const std::string& url );
+        void activate_act_before_popupmenu( const std::string& url ) override;
 
         // tree <-> XML( DOM )変換
         void tree2xml( const std::string& root_name );
@@ -182,49 +182,48 @@ namespace BBSLIST
       public:
 
         BBSListViewBase( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
-        virtual ~BBSListViewBase();
+        ~BBSListViewBase();
 
         //
         // SKELETON::View の関数のオーバロード
         //
 
-        virtual void save_session();
+        void save_session() override;
 
         // 親ウィンドウをセット
-        virtual void set_parent_win( Gtk::Window* parent_win );
+        void set_parent_win( Gtk::Window* parent_win ) override;
 
-        virtual const std::string url_for_copy(){ return std::string(); }
+        const std::string url_for_copy() override { return {}; }
 
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
-        virtual void clock_in();
+        void clock_in() override;
 
         // キーを押した
-        virtual const bool slot_key_press( GdkEventKey* event );
+        const bool slot_key_press( GdkEventKey* event ) override;
 
-        virtual void stop();
-        virtual void redraw_view();
-        virtual void relayout();  // 色やフォントなどの変更
-        virtual void focus_view();
-        virtual void focus_out();
-        virtual void close_view();
-        virtual void delete_view();
+        void stop() override;
+        void redraw_view() override;
+        void relayout() override;  // 色やフォントなどの変更
+        void focus_view() override;
+        void focus_out() override;
+        void close_view() override;
+        void delete_view() override;
 
         // ツリー内の全ての項目をURLを新しいアドレスに変更 ( id は未使用 )
-        virtual void update_item( const std::string& url, const std::string& id );
+        void update_item( const std::string& url, const std::string& id ) override;
 
-        virtual const bool operate_view( const int control );
-        virtual void goto_top();
-        virtual void goto_bottom();
+        const bool operate_view( const int control ) override;
+        void goto_top() override;
+        void goto_bottom() override;
 
         // 検索
-        virtual void exec_search();
-        virtual void up_search();
-        virtual void down_search();
-        virtual void operate_search( const std::string& controlid );
+        void exec_search() override;
+        void up_search() override;
+        void down_search() override;
+        void operate_search( const std::string& controlid ) override;
 
         // 挿入先ダイアログを表示してアイテム追加
         // あらかじめ共有バッファに追加するデータをセットしておくこと

--- a/src/bbslist/columns.cpp
+++ b/src/bbslist/columns.cpp
@@ -19,11 +19,12 @@ TreeColumns::TreeColumns()
     : SKELETON::EditColumns()
 {}
 
-TreeColumns::~TreeColumns()
+TreeColumns::~TreeColumns() noexcept
 {}
 
 void TreeColumns::setup_row( Gtk::TreeModel::Row& row,
-                             const Glib::ustring url, const Glib::ustring name, const Glib::ustring data, const int type, const size_t dirid )
+                             const Glib::ustring url, const Glib::ustring name, const Glib::ustring data,
+                             const int type, const size_t dirid )
 {
     SKELETON::EditColumns::setup_row( row, url, name, data, type, dirid );
 

--- a/src/bbslist/columns.h
+++ b/src/bbslist/columns.h
@@ -17,10 +17,11 @@ namespace BBSLIST
     public:
         
         TreeColumns();
-        virtual ~TreeColumns();
+        ~TreeColumns() noexcept;
 
-        virtual void setup_row( Gtk::TreeModel::Row& row,
-                                const Glib::ustring url, const Glib::ustring name, const Glib::ustring data, const int type, const size_t dirid );
+        void setup_row( Gtk::TreeModel::Row& row,
+                        const Glib::ustring url, const Glib::ustring name, const Glib::ustring data,
+                        const int type, const size_t dirid ) override;
     };
 }
 

--- a/src/bbslist/favoriteview.h
+++ b/src/bbslist/favoriteview.h
@@ -15,16 +15,16 @@ namespace BBSLIST
       public:
 
         FavoriteListView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
-        virtual ~FavoriteListView();
+        ~FavoriteListView();
 
-        virtual void show_view();
+        void show_view() override;
 
       protected:
 
         // xml保存
-        virtual void save_xml();
+        void save_xml() override;
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
     };
 }
 

--- a/src/bbslist/historyview.h
+++ b/src/bbslist/historyview.h
@@ -17,16 +17,16 @@ namespace BBSLIST
 
         HistoryViewBase( const std::string& url, const std::string& file_xml,
                          const std::string& arg1, const std::string& arg2 );
-        virtual ~HistoryViewBase();
+        ~HistoryViewBase();
 
-        virtual void show_view();
+        void show_view() override;
 
       protected:
 
         // xml保存
-        virtual void save_xml();
+        void save_xml() override;
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
     };
 
     ///////////////////////////////////////

--- a/src/bbslist/selectdialog.h
+++ b/src/bbslist/selectdialog.h
@@ -34,19 +34,19 @@ namespace BBSLIST
       public:
 
         SelectListDialog( Gtk::Window* parent, const std::string& url, Glib::RefPtr< Gtk::TreeStore >& treestore );
-        virtual ~SelectListDialog();
+        ~SelectListDialog();
 
         const std::string get_name();
         const std::string get_path();
 
       protected:
 
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
       private:
 
         void slot_show_tree();
-        virtual void timeout();
+        void timeout() override;
     };
 }
 

--- a/src/bbslist/selectlistview.h
+++ b/src/bbslist/selectlistview.h
@@ -23,21 +23,21 @@ namespace BBSLIST
       public:
 
         SelectListView( const std::string& url, const std::string& arg1 = std::string() , const std::string& arg2 = std::string() );
-        virtual ~SelectListView(){}
+        ~SelectListView() noexcept {}
 
         SIG_CLOSE_DIALOG sig_close_dialog() { return m_sig_close_dialog; }
         SIG_FOCUS_ENTRY_SEARCH sig_focus_entry_search() { return m_sig_focus_entry_search; }
 
-        virtual void save_xml(){}
+        void save_xml() override {}
 
-        virtual void close_view();
-        virtual const bool operate_view( const int control );
+        void close_view() override;
+        const bool operate_view( const int control ) override;
 
       private:
 
-        virtual const bool open_row( Gtk::TreePath& path, const bool tab );
-        virtual void switch_rightview(){} // boardに移動しないようにキャンセル
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        const bool open_row( Gtk::TreePath& path, const bool tab ) override;
+        void switch_rightview() override {} // boardに移動しないようにキャンセル
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
     };
 
 }

--- a/src/bbslist/toolbar.h
+++ b/src/bbslist/toolbar.h
@@ -28,14 +28,14 @@ namespace BBSLIST
       public:
 
         BBSListToolBar();
-        virtual ~BBSListToolBar(){}
+        ~BBSListToolBar() noexcept {}
 
         // タブが切り替わった時にDragableNoteBookから呼び出される( Viewの情報を取得する )
-        virtual void set_view( SKELETON::View * view );
+        void set_view( SKELETON::View * view ) override;
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
 
       private:
 
@@ -57,11 +57,11 @@ namespace BBSLIST
       public:
 
         EditListToolBar();
-        virtual ~EditListToolBar(){}
+        ~EditListToolBar() noexcept {}
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
     };
 
 

--- a/src/board/boardadmin.h
+++ b/src/board/boardadmin.h
@@ -24,36 +24,36 @@ namespace BOARD
         BoardAdmin( const std::string& url );
         ~BoardAdmin();
 
-        virtual void save_session();
+        void save_session() override;
 
       protected:
 
-        virtual COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list );
-        virtual SKELETON::View* create_view( const COMMAND_ARGS& command );
+        COMMAND_ARGS get_open_list_args( const std::string& url, const COMMAND_ARGS& command_list ) override;
+        SKELETON::View* create_view( const COMMAND_ARGS& command ) override;
 
         // view_modeに該当するページを探す
-        virtual int find_view( const std::string& view_mode );
+        int find_view( const std::string& view_mode ) override;
 
         // ツールバー
-        virtual void show_toolbar();
-        virtual void toggle_toolbar();
-        virtual void open_searchbar();
-        virtual void close_searchbar();
+        void show_toolbar() override;
+        void toggle_toolbar() override;
+        void open_searchbar() override;
+        void close_searchbar() override;
 
-        virtual void command_local( const COMMAND_ARGS& command );
+        void command_local( const COMMAND_ARGS& command ) override;
 
-        virtual void restore( const bool only_locked );
-        virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock );
-        virtual const std::string command_to_url( const COMMAND_ARGS& command );
+        void restore( const bool only_locked ) override;
+        COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
+        const std::string command_to_url( const COMMAND_ARGS& command ) override;
 
-        virtual void switch_admin();
+        void switch_admin() override;
 
-        virtual void restore_lasttab();
+        void restore_lasttab() override;
 
       private:
 
         // タブをお気に入りにドロップした時にお気に入りがデータ送信を要求してきた
-        virtual void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page );
+        void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override;
     };
     
     BoardAdmin* get_admin();

--- a/src/board/boardview.h
+++ b/src/board/boardview.h
@@ -14,19 +14,19 @@ namespace BOARD
       public:
 
         BoardView( const std::string& url );
-        virtual ~BoardView();
+        ~BoardView();
 
         // SKELETON::View の関数のオーバロード
 
-        virtual void save_session();
+        void save_session() override;
 
-        virtual const bool is_updated();
-        virtual const bool is_check_update();
+        const bool is_updated() override;
+        const bool is_check_update() override;
 
-        virtual void reload();
-        virtual void show_view();
-        virtual void update_view();
-        virtual void update_boardname();
+        void reload() override;
+        void show_view() override;
+        void update_view() override;
+        void update_boardname() override;
     };
 }
 

--- a/src/board/boardviewbase.h
+++ b/src/board/boardviewbase.h
@@ -101,68 +101,67 @@ namespace BOARD
     public:
 
         BoardViewBase( const std::string& url, const bool show_col_board );
-        virtual ~BoardViewBase();
+        ~BoardViewBase();
 
         const std::string& get_url_board() const { return m_url_board; }
-        virtual const std::string url_for_copy();
+        const std::string url_for_copy() override;
 
         // 行数
         const int get_row_size();
 
         // SKELETON::View の関数のオーバロード
 
-        virtual void save_session(){}
+        void save_session() override {}
 
-        virtual void update_url( const std::string& url_old, const std::string& url_new );
+        void update_url( const std::string& url_old, const std::string& url_new ) override;
 
-        virtual const int get_icon( const std::string& iconname );
-        virtual const bool is_loading() const { return m_loading; }
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const int get_icon( const std::string& iconname ) override;
+        const bool is_loading() const override { return m_loading; }
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
-        virtual void clock_in();
+        void clock_in() override;
 
         // キーを押した        
-        virtual const bool slot_key_press( GdkEventKey* event );
+        const bool slot_key_press( GdkEventKey* event ) override;
 
-        virtual void write();
-        virtual void stop();
-        virtual void show_view();
-        virtual void redraw_scrollbar();
-        virtual void relayout();
-        virtual void focus_view();
-        virtual void focus_out();
-        virtual void close_view();
-        virtual void delete_view();
-        virtual void set_favorite();
+        void write() override;
+        void stop() override;
+        void show_view() override;
+        void redraw_scrollbar() override;
+        void relayout() override;
+        void focus_view() override;
+        void focus_out() override;
+        void close_view() override;
+        void delete_view() override;
+        void set_favorite() override;
 
 
         // 特定の行だけの表示内容更新
         // url : subject.txt のアドレス
         // id : DAT の ID(拡張子付き)
         // もし ID が empty() なら全ての行の表示内容を更新する
-        virtual void update_item( const std::string& url, const std::string& id );
+        void update_item( const std::string& url, const std::string& id ) override;
 
-        virtual const bool operate_view( const int control );
-        virtual void goto_top();
-        virtual void goto_bottom();
-        virtual void goto_num( const int num_to, const int num_from );
-        virtual void scroll_left();
-        virtual void scroll_right();
-        virtual void show_preference();
+        const bool operate_view( const int control ) override;
+        void goto_top() override;
+        void goto_bottom() override;
+        void goto_num( const int num_to, const int num_from ) override;
+        void scroll_left() override;
+        void scroll_right() override;
+        void show_preference() override;
 
         // 進む、戻る
-        virtual void back_viewhistory( const int count );
-        virtual void forward_viewhistory( const int count );
+        void back_viewhistory( const int count ) override;
+        void forward_viewhistory( const int count ) override;
 
         // 検索
-        virtual void exec_search();
-        virtual void up_search();
-        virtual void down_search();
-        virtual void operate_search( const std::string& controlid );
-        virtual void set_search_query( const std::string& query );
+        void exec_search() override;
+        void up_search() override;
+        void down_search() override;
+        void operate_search( const std::string& controlid ) override;
+        void set_search_query( const std::string& query ) override;
         void clear_highlight();
 
         void row_up();
@@ -181,13 +180,13 @@ namespace BOARD
         SKELETON::DragTreeView& get_treeview(){ return m_treeview; }
 
         // Viewが所属するAdminクラス
-        virtual SKELETON::Admin* get_admin();
+        SKELETON::Admin* get_admin() override;
 
         // ポップアップメニューを表示する前にメニューのアクティブ状態を切り替える
-        virtual void activate_act_before_popupmenu( const std::string& url );
+        void activate_act_before_popupmenu( const std::string& url ) override;
 
         // ポップアップメニュー取得
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
 
         // view更新
         void update_view_impl( const std::vector< DBTREE::ArticleBase* >& list_article, const bool loading_fin );

--- a/src/board/boardviewlog.h
+++ b/src/board/boardviewlog.h
@@ -18,34 +18,34 @@ namespace BOARD
       public:
 
         BoardViewLog( const std::string& url );
-        virtual ~BoardViewLog();
+        ~BoardViewLog();
 
-        virtual void stop();
-        virtual void reload();
-        virtual void show_view();
-        virtual void update_boardname();
+        void stop() override;
+        void reload() override;
+        void show_view() override;
+        void update_boardname() override;
 
-        virtual void update_item( const std::string& url, const std::string& id );
+        void update_item( const std::string& url, const std::string& id ) override;
 
       protected:
 
         // デフォルトのソート状態
-        virtual const int get_default_sort_column();
-        virtual const int get_default_view_sort_mode();
-        virtual const int get_default_view_sort_pre_column();
-        virtual const int get_default_view_sort_pre_mode();
+        const int get_default_sort_column() override;
+        const int get_default_view_sort_mode() override;
+        const int get_default_view_sort_pre_column() override;
+        const int get_default_view_sort_pre_mode() override;
 
       private:
 
         void slot_search_fin( const std::string& id );
 
-        virtual void slot_abone_thread();
+        void slot_abone_thread() override;
 
         // ソート列やソートモードの保存
-        virtual void save_sort_columns(){} // 保存しない
+        void save_sort_columns() override {} // 保存しない
 
         // 列幅の保存
-        virtual void save_column_width(){} // 保存しない
+        void save_column_width() override {} // 保存しない
     };
 
 }

--- a/src/board/boardviewnext.h
+++ b/src/board/boardviewnext.h
@@ -28,19 +28,19 @@ namespace BOARD
       public:
 
         BoardViewNext( const std::string& url, const std::string& url_pre_article );
-        virtual ~BoardViewNext();
+        ~BoardViewNext();
 
-        virtual void reload();
-        virtual void update_view();
-        virtual void update_boardname();
+        void reload() override;
+        void update_view() override;
+        void update_boardname() override;
 
       protected:
 
         // デフォルトのソート状態
-        virtual const int get_default_sort_column();
-        virtual const int get_default_view_sort_mode();
-        virtual const int get_default_view_sort_pre_column();
-        virtual const int get_default_view_sort_pre_mode();
+        const int get_default_sort_column() override;
+        const int get_default_view_sort_mode() override;
+        const int get_default_view_sort_pre_column() override;
+        const int get_default_view_sort_pre_mode() override;
 
       private:
 
@@ -49,15 +49,15 @@ namespace BOARD
 
         // 次スレ移行処理に使用する前スレのアドレス
         // 次スレ移行処理に使用する。BoardViewBase::open_row()を参照せよ
-        virtual const std::string get_url_pre_article(){ return m_url_pre_article; }
+        const std::string get_url_pre_article() override { return m_url_pre_article; }
 
-        virtual void slot_abone_thread();
+        void slot_abone_thread() override;
 
         // ソート列やソートモードの保存
-        virtual void save_sort_columns(){} // 保存しない
+        void save_sort_columns() override {} // 保存しない
 
         // 列幅の保存
-        virtual void save_column_width(){} // 保存しない
+        void save_column_width() override {} // 保存しない
     };
 
 }

--- a/src/board/boardviewsidebar.h
+++ b/src/board/boardviewsidebar.h
@@ -23,32 +23,32 @@ namespace BOARD
       public:
 
         BoardViewSidebar( const std::string& url, const bool set_history );
-        virtual ~BoardViewSidebar();
+        ~BoardViewSidebar();
 
-        virtual void stop(){}
-        virtual void reload();
-        virtual void show_view();
-        virtual void update_boardname();
+        void stop() override {}
+        void reload() override;
+        void show_view() override;
+        void update_boardname() override;
 
-        virtual void update_item( const std::string& url, const std::string& id );
+        void update_item( const std::string& url, const std::string& id ) override;
 
       protected:
 
         // デフォルトのソート状態
-        virtual const int get_default_sort_column();
-        virtual const int get_default_view_sort_mode();
-        virtual const int get_default_view_sort_pre_column();
-        virtual const int get_default_view_sort_pre_mode();
+        const int get_default_sort_column() override;
+        const int get_default_view_sort_mode() override;
+        const int get_default_view_sort_pre_column() override;
+        const int get_default_view_sort_pre_mode() override;
 
       private:
 
-        virtual void slot_abone_thread();
+        void slot_abone_thread() override;
 
         // ソート列やソートモードの保存
-        virtual void save_sort_columns(){} // 保存しない
+        void save_sort_columns() override {} // 保存しない
 
         // 列幅の保存
-        virtual void save_column_width(){} // 保存しない
+        void save_column_width() override {} // 保存しない
     };
 
 }

--- a/src/board/preference.h
+++ b/src/board/preference.h
@@ -143,7 +143,7 @@ namespace BOARD
 
       public:
         Preferences( Gtk::Window* parent, const std::string& url, const std::string command );
-        virtual ~Preferences();
+        ~Preferences();
 
       private:
         void slot_clear_modified();
@@ -154,8 +154,8 @@ namespace BOARD
         void slot_check_live();
         void slot_remove_old_title();
         void slot_switch_page( GtkNotebookPage*, guint page );
-        virtual void slot_ok_clicked();
-        virtual void timeout();
+        void slot_ok_clicked() override;
+        void timeout() override;
     };
 
 }

--- a/src/board/toolbar.h
+++ b/src/board/toolbar.h
@@ -16,14 +16,14 @@ namespace BOARD
       public:
 
         BoardToolBar();
-        virtual ~BoardToolBar(){}
+        ~BoardToolBar() noexcept {}
 
         // ツールバー表示切り替え時に検索関係の wiget の位置を変更する
         void unpack_pack();
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
 
       private:
 

--- a/src/boarditemmenupref.h
+++ b/src/boarditemmenupref.h
@@ -14,16 +14,16 @@ namespace CORE
       public:
 
         BoardItemMenuPref( Gtk::Window* parent, const std::string& url );
-        virtual ~BoardItemMenuPref(){}
+        ~BoardItemMenuPref() noexcept {}
 
       private:
 
         // OKボタン
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/boarditempref.h
+++ b/src/boarditempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         BoardItemColumnPref( Gtk::Window* parent, const std::string& url );
-        virtual ~BoardItemColumnPref(){}
+        ~BoardItemColumnPref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 
     class BoardItemPref : public SKELETON::SelectItemPref
@@ -30,15 +30,15 @@ namespace CORE
       public:
 
         BoardItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~BoardItemPref(){}
+        ~BoardItemPref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/browserpref.h
+++ b/src/browserpref.h
@@ -25,7 +25,8 @@ namespace CORE
         Gtk::Entry m_entry_browser;
 
         // OK押した
-        virtual void slot_ok_clicked(){
+        void slot_ok_clicked() override
+        {
             CONFIG::set_browsercombo_id( m_combo.get_active_row_number() );
             CONFIG::set_command_openurl( MISC::remove_space( m_entry_browser.get_text() ) );
         }

--- a/src/config/aboutconfig.h
+++ b/src/config/aboutconfig.h
@@ -60,14 +60,14 @@ namespace CONFIG
       public:
 
         AboutConfig( Gtk::Window* parent );
-        virtual ~AboutConfig(){}
+        ~AboutConfig() noexcept {}
 
       private:
 
         void pack_widgets();
 
-        virtual void slot_ok_clicked();
-        virtual void slot_cancel_clicked();
+        void slot_ok_clicked() override;
+        void slot_cancel_clicked() override;
 
         void slot_cell_data( Gtk::CellRenderer* cell, const Gtk::TreeModel::iterator& it );
 

--- a/src/config/aboutconfigdiag.h
+++ b/src/config/aboutconfigdiag.h
@@ -23,7 +23,7 @@ namespace CONFIG
         AboutConfigDiagStr( Gtk::Window* parent, std::string* value, const std::string& defaultval );
 
       protected:
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         void slot_default();
     };
@@ -46,7 +46,7 @@ namespace CONFIG
         AboutConfigDiagInt( Gtk::Window* parent, int* value, const int defaultval );
 
       protected:
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         void slot_default();
     };
@@ -71,7 +71,7 @@ namespace CONFIG
         AboutConfigDiagBool( Gtk::Window* parent, bool* value, const bool defaultval );
 
       protected:
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         void slot_default();
     };

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -66,7 +66,7 @@ ConfigItems::ConfigItems()
     fontname.resize( FONT_NUM );
 }
 
-ConfigItems::~ConfigItems()
+ConfigItems::~ConfigItems() noexcept
 {}
 
 // 設定読み込み

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -528,7 +528,7 @@ namespace CONFIG
 
 
         ConfigItems();
-        virtual ~ConfigItems();
+        virtual ~ConfigItems() noexcept;
 
         // 設定読み込み
         const bool load( const bool restore = false );

--- a/src/control/buttonconfig.cpp
+++ b/src/control/buttonconfig.cpp
@@ -23,7 +23,7 @@ ButtonConfig::ButtonConfig()
 {}
 
 
-ButtonConfig::~ButtonConfig()
+ButtonConfig::~ButtonConfig() noexcept
 {}
 
 

--- a/src/control/buttonconfig.h
+++ b/src/control/buttonconfig.h
@@ -15,9 +15,9 @@ namespace CONTROL
       public:
 
         ButtonConfig();
-        virtual ~ButtonConfig();
+        ~ButtonConfig() noexcept;
 
-        virtual void load_conf();
+        void load_conf() override;
 
         const bool is_toggled_tab_button(); // タブで開くボタンを入れ替えているか
         void toggle_tab_button( const bool toggle ); // タブで開くボタンを入れ替える
@@ -28,7 +28,8 @@ namespace CONTROL
       private:
 
         // ひとつの操作をデータベースに登録
-        virtual void set_one_motion_impl( const int id, const int mode, const std::string& name, const std::string& str_motion );
+        void set_one_motion_impl( const int id, const int mode,
+                                  const std::string& name, const std::string& str_motion ) override;
     };
 }
 

--- a/src/control/buttonpref.h
+++ b/src/control/buttonpref.h
@@ -39,9 +39,9 @@ namespace CONTROL
 
       protected:
 
-        virtual InputDiag* create_inputdiag();
-        virtual const std::string get_default_motions( const int id );
-        virtual const std::vector< int > check_conflict( const int mode, const std::string& str_motion );
+        InputDiag* create_inputdiag() override;
+        const std::string get_default_motions( const int id ) override;
+        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 
@@ -59,15 +59,15 @@ namespace CONTROL
 
       protected:
 
-        virtual MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions );
-        virtual const std::string get_str_motions( const int id );
-        virtual const std::string get_default_motions( const int id );
-        virtual void set_motions( const int id, const std::string& str_motions );
-        virtual const bool remove_motions( const int id );
+        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        const std::string get_str_motions( const int id ) override;
+        const std::string get_default_motions( const int id ) override;
+        void set_motions( const int id, const std::string& str_motions ) override;
+        const bool remove_motions( const int id ) override;
 
       private:
 
-        virtual void slot_cancel_clicked();
+        void slot_cancel_clicked() override;
     };
 
 }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -86,7 +86,7 @@ const int Control::key_press( const GdkEventKey* event )
     if( CONTROL::is_ascii( key ) && ( key < 'A' || key > 'Z' ) ) shift = false;
 
 #ifdef _DEBUG
-    std::cout << "Control::key_press key = " << std::hex << key;
+    std::cout << "Control::key_press key = " << std::hex << key << std::dec;
     if( ctrl ) std::cout << " ctrl";
     if( shift ) std::cout << " shift";
     if( alt ) std::cout << " alt";

--- a/src/control/keyconfig.cpp
+++ b/src/control/keyconfig.cpp
@@ -25,7 +25,7 @@ KeyConfig::KeyConfig()
 {}
 
 
-KeyConfig::~KeyConfig()
+KeyConfig::~KeyConfig() noexcept
 {}
 
 

--- a/src/control/keyconfig.h
+++ b/src/control/keyconfig.h
@@ -17,9 +17,9 @@ namespace CONTROL
       public:
 
         KeyConfig();
-        virtual ~KeyConfig();
+        ~KeyConfig() noexcept;
 
-        virtual void load_conf();
+        void load_conf() override;
 
         // editviewの操作をemacs風にする
         const bool is_emacs_mode();
@@ -34,7 +34,8 @@ namespace CONTROL
       private:
 
         // ひとつの操作をデータベースに登録
-        virtual void set_one_motion_impl( const int id, const int mode, const std::string& name, const std::string& str_motion );
+        void set_one_motion_impl( const int id, const int mode,
+                                  const std::string& name, const std::string& str_motion ) override;
     };
 }
 

--- a/src/control/keypref.h
+++ b/src/control/keypref.h
@@ -37,9 +37,9 @@ namespace CONTROL
 
       protected:
 
-        virtual InputDiag* create_inputdiag();
-        virtual const std::string get_default_motions( const int id );
-        virtual const std::vector< int > check_conflict( const int mode, const std::string& str_motion );
+        InputDiag* create_inputdiag() override;
+        const std::string get_default_motions( const int id ) override;
+        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 
@@ -56,15 +56,15 @@ namespace CONTROL
 
       protected:
 
-        virtual MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions );
-        virtual const std::string get_str_motions( const int id );
-        virtual const std::string get_default_motions( const int id );
-        virtual void set_motions( const int id, const std::string& str_motions );
-        virtual const bool remove_motions( const int id );
+        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        const std::string get_str_motions( const int id ) override;
+        const std::string get_default_motions( const int id ) override;
+        void set_motions( const int id, const std::string& str_motions ) override;
+        const bool remove_motions( const int id ) override;
 
       private:
 
-        virtual void slot_cancel_clicked();
+        void slot_cancel_clicked() override;
     };
 
 }

--- a/src/control/mouseconfig.cpp
+++ b/src/control/mouseconfig.cpp
@@ -24,7 +24,7 @@ MouseConfig::MouseConfig()
 
 
 
-MouseConfig::~MouseConfig()
+MouseConfig::~MouseConfig() noexcept
 {}
 
 

--- a/src/control/mouseconfig.h
+++ b/src/control/mouseconfig.h
@@ -16,20 +16,21 @@ namespace CONTROL
       public:
 
         MouseConfig();
-        virtual ~MouseConfig();
+        ~MouseConfig() noexcept;
 
-        virtual void load_conf();
+        void load_conf() override;
 
         // 操作文字列取得
-        virtual const std::string get_str_motions( const int id );
+        const std::string get_str_motions( const int id ) override;
 
         // IDからデフォルトの操作文字列取得
-        virtual const std::string get_default_motions( const int id );
+        const std::string get_default_motions( const int id ) override;
 
       private:
 
         // ひとつの操作をデータベースに登録
-        virtual void set_one_motion_impl( const int id, const int mode, const std::string& name, const std::string& str_motion );
+        void set_one_motion_impl( const int id, const int mode,
+                                  const std::string& name, const std::string& str_motion ) override;
     };
 }
 

--- a/src/control/mousekeyconf.cpp
+++ b/src/control/mousekeyconf.cpp
@@ -21,7 +21,7 @@ MouseKeyConf::MouseKeyConf()
 
 
 
-MouseKeyConf::~MouseKeyConf()
+MouseKeyConf::~MouseKeyConf() noexcept
 {}
 
 

--- a/src/control/mousekeyconf.h
+++ b/src/control/mousekeyconf.h
@@ -26,7 +26,7 @@ namespace CONTROL
       public:
 
         MouseKeyConf();
-        virtual ~MouseKeyConf();
+        virtual ~MouseKeyConf() noexcept;
 
         // 設定ファイル読み込み 
         virtual void load_conf() = 0;

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -69,7 +69,7 @@ bool InputDiag::on_key_press_event( GdkEventKey* event )
         if( CONTROL::is_ascii( key ) ) shift = false;
 
 #ifdef _DEBUG
-        std::cout << "InputDiag::on_key_press_event key = " << std::hex << key;
+        std::cout << "InputDiag::on_key_press_event key = " << std::hex << key << std::dec;
         if( ctrl ) std::cout << " ctrl";
         if( shift ) std::cout << " shift";
         if( alt ) std::cout << " alt";

--- a/src/control/mousepref.h
+++ b/src/control/mousepref.h
@@ -38,9 +38,9 @@ namespace CONTROL
 
       protected:
 
-        virtual InputDiag* create_inputdiag();
-        virtual const std::string get_default_motions( const int id );
-        virtual const std::vector< int > check_conflict( const int mode, const std::string& str_motion );
+        InputDiag* create_inputdiag() override;
+        const std::string get_default_motions( const int id ) override;
+        const std::vector< int > check_conflict( const int mode, const std::string& str_motion ) override;
     };
 
 
@@ -58,15 +58,15 @@ namespace CONTROL
 
       protected:
 
-        virtual MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions );
-        virtual const std::string get_str_motions( const int id );
-        virtual const std::string get_default_motions( const int id );
-        virtual void set_motions( const int id, const std::string& str_motions );
-        virtual const bool remove_motions( const int id );
+        MouseKeyDiag* create_setting_diag( const int id, const std::string& str_motions ) override;
+        const std::string get_str_motions( const int id ) override;
+        const std::string get_default_motions( const int id ) override;
+        void set_motions( const int id, const std::string& str_motions ) override;
+        const bool remove_motions( const int id ) override;
 
       private:
 
-        virtual void slot_cancel_clicked();
+        void slot_cancel_clicked() override;
     };
 
 }

--- a/src/core.h
+++ b/src/core.h
@@ -112,7 +112,7 @@ namespace CORE
     public:
 
         Core( JDWinMain& win_main );
-        virtual ~Core();
+        ~Core();
 
         Gtk::Widget* get_toplevel();
 
@@ -169,7 +169,7 @@ namespace CORE
         void toggle_sidebar();
         void slot_show_hide_leftpane( int mode );
 
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
 
         // coreが自前でするコマンド処理
         void exec_command();

--- a/src/cssmanager.h
+++ b/src/cssmanager.h
@@ -147,7 +147,7 @@ namespace CORE
     public:
 
         Css_Manager();
-        virtual ~Css_Manager(){}
+        virtual ~Css_Manager() noexcept {}
 
         // ユーザ設定の色取得
         std::string get_color( int colorid );

--- a/src/dbimg/delimgcachediag.h
+++ b/src/dbimg/delimgcachediag.h
@@ -35,11 +35,11 @@ namespace DBIMG
 
       protected:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
 
       private:
 
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
         void wait();
         void slot_cancel_clicked();
         time_t get_days( const std::string& path );

--- a/src/dbimg/delimgdiag.h
+++ b/src/dbimg/delimgdiag.h
@@ -96,7 +96,8 @@ namespace DBIMG
         ImgAboneFrame m_frame_abone;
 
         // OK押した
-        virtual void slot_ok_clicked(){
+        void slot_ok_clicked() override
+        {
             CONFIG::set_del_img_day( m_frame_cache.get_spin().get_value_as_int() );
             CONFIG::set_del_imgabone_day( m_frame_abone.get_spin().get_value_as_int() );
         }
@@ -118,7 +119,7 @@ namespace DBIMG
             show_all_children();
         }
 
-        virtual ~DelImgDiag(){}
+        ~DelImgDiag() noexcept {}
     };
 
 }

--- a/src/dbimg/img.h
+++ b/src/dbimg/img.h
@@ -117,14 +117,14 @@ namespace DBIMG
         void download_img( const std::string refurl, const bool mosaic, const int waitsec );
 
         // ロード停止
-        virtual void stop_load();
+        void stop_load() override;
 
         const bool save( Gtk::Window* parent, const std::string& path_to );
         
       private:
 
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
 
         // ロード待ち状態セット/リセット
         const bool set_wait( const std::string& refurl, const bool mosaic, const int waitsec );

--- a/src/dbtree/article2ch.cpp
+++ b/src/dbtree/article2ch.cpp
@@ -25,7 +25,7 @@ Article2ch::Article2ch( const std::string& datbase, const std::string& id, bool 
 {}
 
 
-Article2ch::~Article2ch()
+Article2ch::~Article2ch() noexcept
 {}
 
 

--- a/src/dbtree/article2ch.h
+++ b/src/dbtree/article2ch.h
@@ -16,25 +16,26 @@ namespace DBTREE
       public:
 
         Article2ch( const std::string& datbase, const std::string& id, bool cached );
-        ~Article2ch();
+        ~Article2ch() noexcept;
 
         // 書き込みメッセージ変換
-        virtual const std::string create_write_message( const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_write_message( const std::string& name, const std::string& mail,
+                                                const std::string& msg ) override;
 
         // bbscgi のURL
-        virtual const std::string url_bbscgi();
+        const std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        virtual const std::string url_subbbscgi();
+        const std::string url_subbbscgi() override;
 
       protected:
 
         // dat落ちしたスレをロードするか
-        virtual const bool is_load_olddat();
+        const bool is_load_olddat() override;
 
       private:
         
-        virtual NodeTreeBase* create_nodetree();
+        NodeTreeBase* create_nodetree() override;
     };
 }
 

--- a/src/dbtree/article2chcompati.cpp
+++ b/src/dbtree/article2chcompati.cpp
@@ -35,7 +35,7 @@ Article2chCompati::Article2chCompati( const std::string& datbase, const std::str
 
 
 
-Article2chCompati::~Article2chCompati()
+Article2chCompati::~Article2chCompati() noexcept
 {}
 
 

--- a/src/dbtree/article2chcompati.h
+++ b/src/dbtree/article2chcompati.h
@@ -16,20 +16,21 @@ namespace DBTREE
       public:
 
         Article2chCompati( const std::string& datbase, const std::string& id, bool cached );
-        virtual ~Article2chCompati();
+        ~Article2chCompati() noexcept;
 
         // 書き込みメッセージ変換
-        virtual const std::string create_write_message( const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_write_message( const std::string& name, const std::string& mail,
+                                                const std::string& msg ) override;
 
         // bbscgi のURL
-        virtual const std::string url_bbscgi();
+        const std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        virtual const std::string url_subbbscgi();
+        const std::string url_subbbscgi() override;
 
       private:
         
-        virtual NodeTreeBase* create_nodetree();
+        NodeTreeBase* create_nodetree() override;
     };
 }
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -119,7 +119,7 @@ namespace DBTREE
       public:
 
         ArticleBase( const std::string& datbase, const std::string& id, bool cached );
-        virtual ~ArticleBase();
+        ~ArticleBase();
 
         const bool empty();
 
@@ -416,7 +416,7 @@ namespace DBTREE
 
         void slot_node_updated();
         void slot_load_finished();
-        virtual void unlock_impl();
+        void unlock_impl() override;
 
         // お気に入りのアイコンとスレビューのタブのアイコンに更新マークを表示
         // update == true の時に表示。falseなら戻す

--- a/src/dbtree/articlejbbs.h
+++ b/src/dbtree/articlejbbs.h
@@ -21,20 +21,21 @@ namespace DBTREE
         ~ArticleJBBS();
 
         // 書き込みメッセージ変換
-        virtual const std::string create_write_message( const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_write_message( const std::string& name, const std::string& mail,
+                                                const std::string& msg ) override;
 
         // bbscgi のURL
-        virtual const std::string url_bbscgi();
+        const std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        virtual const std::string url_subbbscgi();
+        const std::string url_subbbscgi() override;
 
       private:
         
         // 更新チェック不可能
-        virtual const bool enable_check_update(){ return false; }
+        const bool enable_check_update() override { return false; }
 
-        virtual NodeTreeBase* create_nodetree();
+        NodeTreeBase* create_nodetree() override;
     };
 }
 

--- a/src/dbtree/articlelocal.h
+++ b/src/dbtree/articlelocal.h
@@ -19,20 +19,20 @@ namespace DBTREE
         ~ArticleLocal();
 
         // ID がこのスレのものかどうか
-        virtual const bool equal( const std::string& datbase, const std::string& id );
+        const bool equal( const std::string& datbase, const std::string& id ) override;
 
         // キャッシュの削除をしない
-        virtual void delete_cache( const bool cache_only ){}
+        void delete_cache( const bool cache_only ) override {}
 
         // 情報ファイルを保存しない
-        virtual void save_info( const bool force ){}
+        void save_info( const bool force ) override {}
 
         // ダウンロードしない
-        virtual void download_dat( const bool check_update ){}
+        void download_dat( const bool check_update ) override {}
 
       private:
         
-        virtual NodeTreeBase* create_nodetree();
+        NodeTreeBase* create_nodetree() override;
     };
 }
 

--- a/src/dbtree/articlemachi.cpp
+++ b/src/dbtree/articlemachi.cpp
@@ -30,7 +30,7 @@ ArticleMachi::ArticleMachi( const std::string& datbase, const std::string& _id, 
 }
 
 
-ArticleMachi::~ArticleMachi()
+ArticleMachi::~ArticleMachi() noexcept
 {}
 
 

--- a/src/dbtree/articlemachi.h
+++ b/src/dbtree/articlemachi.h
@@ -18,23 +18,24 @@ namespace DBTREE
       public:
 
         ArticleMachi( const std::string& datbase, const std::string& id, bool cached );
-        ~ArticleMachi();
+        ~ArticleMachi() noexcept;
 
         // 書き込みメッセージ変換
-        virtual const std::string create_write_message( const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_write_message( const std::string& name, const std::string& mail,
+                                                const std::string& msg ) override;
 
         // bbscgi のURL
-        virtual const std::string url_bbscgi();
+        const std::string url_bbscgi() override;
         
         // subbbscgi のURL
-        virtual const std::string url_subbbscgi();
+        const std::string url_subbbscgi() override;
 
       private:
         
         // offlawモードなら更新チェック可能
-        virtual const bool enable_check_update();
+        const bool enable_check_update() override;
 
-        virtual NodeTreeBase* create_nodetree();
+        NodeTreeBase* create_nodetree() override;
     };
 }
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -31,7 +31,7 @@ Board2ch::Board2ch( const std::string& root, const std::string& path_board, cons
 }
 
 
-Board2ch::~Board2ch()
+Board2ch::~Board2ch() noexcept
 {}
 
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -22,56 +22,56 @@ namespace DBTREE
       public:
 
         Board2ch( const std::string& root, const std::string& path_board,const std::string& name );
-        virtual ~Board2ch();
+        ~Board2ch() noexcept;
 
         // ユーザーエージェント
-        virtual const std::string& get_agent(); // ダウンロード用
-        virtual const std::string& get_agent_w(); // 書き込み用
+        const std::string& get_agent() override; // ダウンロード用
+        const std::string& get_agent_w() override; // 書き込み用
 
         // 読み込み用プロキシ
-        virtual const std::string get_proxy_host();
-        virtual const int get_proxy_port();
-        virtual const std::string get_proxy_basicauth();
+        const std::string get_proxy_host() override;
+        const int get_proxy_port() override;
+        const std::string get_proxy_basicauth() override;
 
         // 書き込み用プロキシ
-        virtual const std::string get_proxy_host_w();
-        virtual const int get_proxy_port_w();
-        virtual const std::string get_proxy_basicauth_w();
+        const std::string get_proxy_host_w() override;
+        const int get_proxy_port_w() override;
+        const std::string get_proxy_basicauth_w() override;
 
         // 書き込み用クッキー
-        virtual const std::string cookie_for_write();
+        const std::string cookie_for_write() override;
 
         // 書き込み時のリファラ
-        virtual const std::string get_write_referer();
+        const std::string get_write_referer() override;
 
         // 新スレ作成用のメッセージ変換
-        virtual const std::string create_newarticle_message( const std::string& subject,
-                                                             const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                                     const std::string& mail, const std::string& msg ) override;
 
         // 新スレ作成用のbbscgi のURL
-        virtual const std::string url_bbscgi_new();
+        const std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        virtual const std::string url_subbbscgi_new();
+        const std::string url_subbbscgi_new() override;
 
         // datの最大サイズ(Kバイト)
-        virtual const int get_max_dat_lng() const { return DEFAULT_MAX_DAT_LNG; }
+        const int get_max_dat_lng() const override { return DEFAULT_MAX_DAT_LNG; }
 
       protected:
 
         // クッキー:HAP
-        virtual const std::string get_hap();
-        virtual void set_hap( const std::string& hap );
+        const std::string get_hap() override;
+        void set_hap( const std::string& hap ) override;
 
         // クッキー:HAPの更新 (クッキーをセットした時に実行)
-        virtual void update_hap();
+        void update_hap() override;
 
       private:
 
         // デフォルト最大レス数
-        virtual const int get_default_number_max_res() { return DEFAULT_NUMBER_MAX_2CH; }
+        const int get_default_number_max_res() override { return DEFAULT_NUMBER_MAX_2CH; }
 
-        virtual ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached );
+        ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
     };
 }
 

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -22,47 +22,48 @@ namespace DBTREE
       public:
 
         Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name, const std::string& basicauth );
-        virtual ~Board2chCompati();
+        ~Board2chCompati();
 
         // 書き込み用クッキー
-        virtual const std::string cookie_for_write();
+        const std::string cookie_for_write() override;
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      
-        virtual void analyze_keyword_for_write( const std::string& html );
+        void analyze_keyword_for_write( const std::string& html ) override;
 
         // 新スレ作成用のメッセージ変換
-        virtual const std::string create_newarticle_message( const std::string& subject,
-                                                             const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                                     const std::string& mail, const std::string& msg ) override;
+
         // 新スレ作成用のbbscgi のURL
-        virtual const std::string url_bbscgi_new();
+        const std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        virtual const std::string url_subbbscgi_new();
+        const std::string url_subbbscgi_new() override;
 
         // ローカルルール
-        virtual const std::string localrule();
+        const std::string localrule() override;
 
         // SETTING.TXT 
-        virtual const std::string settingtxt();
-        virtual const std::string default_noname();
-        virtual const int line_number();
-        virtual const int message_count();
-        virtual const std::string get_unicode();
+        const std::string settingtxt() override;
+        const std::string default_noname() override;
+        const int line_number() override;
+        const int message_count() override;
+        const std::string get_unicode() override;
 
       private:
 
-        virtual const bool is_valid( const std::string& filename );
+        const bool is_valid( const std::string& filename ) override;
 
-        virtual ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached );
-        virtual void parse_subject( const char* str_subject_txt );
-        virtual void regist_article( const bool is_online );
+        ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
+        void parse_subject( const char* str_subject_txt ) override;
+        void regist_article( const bool is_online ) override;
 
-        virtual void load_rule_setting();
-        virtual void download_rule_setting();
+        void load_rule_setting() override;
+        void download_rule_setting() override;
 
         // レス数であぼーん(グローバル)
-        virtual const int get_abone_number_global();
+        const int get_abone_number_global() override;
     };
 }
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -246,7 +246,7 @@ namespace DBTREE
       public:
 
         BoardBase( const std::string& root, const std::string& path_board, const std::string& name );
-        virtual ~BoardBase();
+        ~BoardBase();
         bool empty();
 
         // 状態 ( global.hで定義 )
@@ -567,8 +567,8 @@ namespace DBTREE
         virtual const bool is_valid( const std::string& filename ){ return false; }
 
         virtual void create_loaderdata( JDLIB::LOADERDATA& data );
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
 
         // url_boardbase をロードして移転したかどうか解析開始
         bool start_checkking_if_board_moved();

--- a/src/dbtree/boardjbbs.h
+++ b/src/dbtree/boardjbbs.h
@@ -17,23 +17,24 @@ namespace DBTREE
 
         BoardJBBS( const std::string& root, const std::string& path_board,const std::string& name );
 
-        virtual const std::string url_datpath();
+        const std::string url_datpath() override;
 
         // 新スレ作成用のメッセージ変換
-        virtual const std::string create_newarticle_message( const std::string& subject,
-                                                             const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                                     const std::string& mail, const std::string& msg ) override;
+
         // 新スレ作成用のbbscgi のURL
-        virtual const std::string url_bbscgi_new();
+        const std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        virtual const std::string url_subbbscgi_new();
+        const std::string url_subbbscgi_new() override;
 
       private:
 
-        virtual const bool is_valid( const std::string& filename );
-        virtual ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached );
-        virtual void parse_subject( const char* str_subject_txt );
-        virtual void regist_article( const bool is_online );
+        const bool is_valid( const std::string& filename ) override;
+        ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
+        void parse_subject( const char* str_subject_txt ) override;
+        void regist_article( const bool is_online ) override;
     };
 }
 

--- a/src/dbtree/boardlocal.cpp
+++ b/src/dbtree/boardlocal.cpp
@@ -24,7 +24,7 @@ BoardLocal::BoardLocal( const std::string& root, const std::string& path_board, 
 }
 
 
-BoardLocal::~BoardLocal()
+BoardLocal::~BoardLocal() noexcept
 {}
 
 

--- a/src/dbtree/boardlocal.h
+++ b/src/dbtree/boardlocal.h
@@ -16,35 +16,35 @@ namespace DBTREE
       public:
 
         BoardLocal( const std::string& root, const std::string& path_board, const std::string& name );
-        virtual ~BoardLocal();
+        ~BoardLocal() noexcept;
 
         // url がこの板のものかどうか
-        virtual bool equal( const std::string& url );
+        bool equal( const std::string& url ) override;
 
-        virtual const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ); 
-        virtual const std::string url_readcgi( const std::string& url, int num_from, int num_to );
+        const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
+        const std::string url_readcgi( const std::string& url, int num_from, int num_to ) override;
 
-        virtual void download_subject( const std::string& url_update_view, const bool );
+        void download_subject( const std::string& url_update_view, const bool ) override;
 
         // 板情報の読み書きをキャンセル
-        virtual void read_info(){}
-        virtual void save_info(){}
+        void read_info() override {}
+        void save_info() override {}
 
         // キャッシュサーチをキャンセル
-        virtual void search_cache( std::vector< ArticleBase* >&, const std::string&,
-                                   const bool, const bool, const bool& ) {}
+        void search_cache( std::vector< ArticleBase* >&, const std::string&, const bool, const bool,
+                           const bool& ) override {}
 
         // datファイルのインポート
-        virtual const std::string import_dat( const std::string& filename );
+        const std::string import_dat( const std::string& filename ) override;
 
       private:
 
-        virtual ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached );
+        ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
 
-        virtual void append_all_article_in_cache(){}
+        void append_all_article_in_cache() override {}
 
-        virtual void load_rule_setting(){}
-        virtual void download_rule_setting(){}
+        void load_rule_setting() override {}
+        void download_rule_setting() override {}
     };
 }
 

--- a/src/dbtree/boardmachi.h
+++ b/src/dbtree/boardmachi.h
@@ -18,30 +18,31 @@ namespace DBTREE
         BoardMachi( const std::string& root, const std::string& path_board,const std::string& name );
 
         // url がこの板のものかどうか
-        virtual bool equal( const std::string& url );
+        bool equal( const std::string& url ) override;
 
         // スレの url を dat型のurlに変換して出力
         // (例) "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345&START=12&END=15"" のとき
         // 戻り値 : "http://hoge.machi.to/bbs/read.cgi?BBS=board&KEY=12345", num_from = 12, num_to = 15, num_str = 12-15
-        virtual const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str );
+        const std::string url_dat( const std::string& url, int& num_from, int& num_to, std::string& num_str ) override;
 
-        virtual const std::string url_datpath();
+        const std::string url_datpath() override;
 
         // 新スレ作成用のメッセージ変換
-        virtual const std::string create_newarticle_message( const std::string& subject,
-                                                             const std::string& name, const std::string& mail, const std::string& msg );
+        const std::string create_newarticle_message( const std::string& subject, const std::string& name,
+                                                     const std::string& mail, const std::string& msg ) override;
+
         // 新スレ作成用のbbscgi のURL
-        virtual const std::string url_bbscgi_new();
+        const std::string url_bbscgi_new() override;
         
         // 新スレ作成用のsubbbscgi のURL
-        virtual const std::string url_subbbscgi_new();
+        const std::string url_subbbscgi_new() override;
 
       private:
 
-        virtual const bool is_valid( const std::string& filename );
-        virtual ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached );
-        virtual void parse_subject( const char* str_subject_txt );
-        virtual void regist_article( const bool is_online );
+        const bool is_valid( const std::string& filename ) override;
+        ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
+        void parse_subject( const char* str_subject_txt ) override;
+        void regist_article( const bool is_online ) override;
     };
 }
 

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -26,13 +26,13 @@ namespace DBTREE
 
       protected:
 
-        virtual char* process_raw_lines( char* rawlines );
+        char* process_raw_lines( char* rawlines ) override;
 
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
       private:
 
-        virtual void receive_finish();
+        void receive_finish() override;
     };
 }
 

--- a/src/dbtree/nodetree2chcompati.h
+++ b/src/dbtree/nodetree2chcompati.h
@@ -23,18 +23,18 @@ namespace DBTREE
       public:
 
         NodeTree2chCompati( const std::string& url, const std::string& date_modified );
-        virtual ~NodeTree2chCompati();
+        ~NodeTree2chCompati();
 
       protected:
 
-        virtual void clear();
-        virtual void init_loading();
-        virtual char* process_raw_lines( char* rawlines );
-        virtual const char* raw2dat( char* rawlines, int& byte );
+        void clear() override;
+        void init_loading() override;
+        char* process_raw_lines( char* rawlines ) override;
+        const char* raw2dat( char* rawlines, int& byte ) override;
 
         char* skip_status_line( char* pos, int status );
 
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
     };
 }
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -140,7 +140,7 @@ namespace DBTREE
       public:
 
         NodeTreeBase( const std::string& url, const std::string& date_modified );
-        virtual ~NodeTreeBase();
+        ~NodeTreeBase();
 
         bool empty();
         void update_url( const std::string& url );
@@ -279,8 +279,8 @@ namespace DBTREE
             return rawlines;
         }
 
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
 
       private:
 

--- a/src/dbtree/nodetreedummy.h
+++ b/src/dbtree/nodetreedummy.h
@@ -16,10 +16,10 @@ namespace DBTREE
       public:
 
         NodeTreeDummy( const std::string& url );
-        virtual ~NodeTreeDummy();
+        ~NodeTreeDummy();
 
         // ダウンロードしない
-        virtual void download_dat( const bool check_update ){}
+        void download_dat( const bool check_update ) override {}
     };
 }
 

--- a/src/dbtree/nodetreejbbs.h
+++ b/src/dbtree/nodetreejbbs.h
@@ -29,10 +29,10 @@ namespace DBTREE
 
       protected:
 
-        virtual void clear();
-        virtual void init_loading();
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
-        virtual const char* raw2dat( char* rawlines, int& byte );
+        void clear() override;
+        void init_loading() override;
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
+        const char* raw2dat( char* rawlines, int& byte ) override;
     };
 }
 

--- a/src/dbtree/nodetreelocal.h
+++ b/src/dbtree/nodetreelocal.h
@@ -16,10 +16,10 @@ namespace DBTREE
       public:
 
         NodeTreeLocal( const std::string& url );
-        virtual ~NodeTreeLocal();
+        ~NodeTreeLocal();
 
         // ダウンロードしない
-        virtual void download_dat( const bool check_update ){}
+        void download_dat( const bool check_update ) override {}
     };
 }
 

--- a/src/dbtree/nodetreemachi.h
+++ b/src/dbtree/nodetreemachi.h
@@ -37,14 +37,14 @@ namespace DBTREE
 
       protected:
 
-        virtual void clear();
-        virtual void init_loading();
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
-        virtual char* process_raw_lines( char* rawlines );
-        virtual const char* raw2dat( char* rawlines, int& byte );
+        void clear() override;
+        void init_loading() override;
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
+        char* process_raw_lines( char* rawlines ) override;
+        const char* raw2dat( char* rawlines, int& byte ) override;
 
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
     };
 }
 

--- a/src/dbtree/root.h
+++ b/src/dbtree/root.h
@@ -155,8 +155,8 @@ namespace DBTREE
 
         // bbsmenuのダウンロード用関数
         void clear();
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
         void bbsmenu2xml( const std::string& menu );
 
         // XML に含まれる板情報を取り出してデータベースを更新

--- a/src/dbtree/ruleloader.h
+++ b/src/dbtree/ruleloader.h
@@ -28,15 +28,15 @@ namespace DBTREE
 
       protected:
 
-        virtual const std::string get_url();
-        virtual const std::string get_path();
-        virtual const std::string get_charset();
+        const std::string get_url() override;
+        const std::string get_path() override;
+        const std::string get_charset() override;
 
         // ロード用データ作成
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
         // ロード後に呼び出される
-        virtual void parse_data();
+        void parse_data() override;
     };
 }
 

--- a/src/dbtree/settingloader.h
+++ b/src/dbtree/settingloader.h
@@ -45,15 +45,15 @@ namespace DBTREE
 
       protected:
 
-        virtual const std::string get_url();
-        virtual const std::string get_path();
-        virtual const std::string get_charset();
+        const std::string get_url() override;
+        const std::string get_path() override;
+        const std::string get_charset() override;
 
         // ロード用データ作成
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
         // ロード後に呼び出される
-        virtual void parse_data();
+        void parse_data() override;
     };
 }
 

--- a/src/dndmanager.h
+++ b/src/dndmanager.h
@@ -27,7 +27,7 @@ namespace CORE
       public:
 
         DND_Manager():m_dnd( false ){}
-        virtual ~DND_Manager(){}
+        virtual ~DND_Manager() noexcept {}
 
         const bool now_dnd() const{ return m_dnd; }
 

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -111,7 +111,7 @@ FontColorPref::FontColorPref( Gtk::Window* parent, const std::string& url )
 }
 
 
-FontColorPref::~FontColorPref()
+FontColorPref::~FontColorPref() noexcept
 {}
 
 

--- a/src/fontcolorpref.h
+++ b/src/fontcolorpref.h
@@ -85,7 +85,7 @@ namespace CORE
       public:
 
         FontColorPref( Gtk::Window* parent, const std::string& url );
-        ~FontColorPref();
+        ~FontColorPref() noexcept;
 
       private:
 
@@ -110,9 +110,9 @@ namespace CORE
         void slot_reset_all_colors();
 
         // OK,cancel,apply が押された
-        virtual void slot_ok_clicked();
-        virtual void slot_apply_clicked();
-        virtual void slot_cancel_clicked();
+        void slot_ok_clicked() override;
+        void slot_apply_clicked() override;
+        void slot_cancel_clicked() override;
     };
 }
 

--- a/src/globalabonepref.h
+++ b/src/globalabonepref.h
@@ -23,7 +23,8 @@ namespace CORE
         Gtk::Label m_label_warning;
 
         // OK押した
-        virtual void slot_ok_clicked(){
+        void slot_ok_clicked() override
+        {
 
             // 全体あぼーん再設定
             std::list< std::string > list_name = MISC::get_lines( m_edit_name.get_text() );
@@ -75,7 +76,7 @@ namespace CORE
             show_all_children();
         }
 
-        virtual ~GlobalAbonePref(){}
+        ~GlobalAbonePref() noexcept {}
     };
 
 }

--- a/src/globalabonethreadpref.h
+++ b/src/globalabonethreadpref.h
@@ -36,7 +36,8 @@ namespace CORE
         SKELETON::SpinButton m_spin_hour;
 
         // OK押した
-        virtual void slot_ok_clicked(){
+        void slot_ok_clicked() override
+        {
 
             // 全体あぼーん再設定
 
@@ -119,7 +120,7 @@ namespace CORE
             show_all_children();
         }
 
-        virtual ~GlobalAboneThreadPref(){}
+        ~GlobalAboneThreadPref() noexcept {}
     };
 
 }

--- a/src/history/historysubmenu.h
+++ b/src/history/historysubmenu.h
@@ -26,7 +26,7 @@ namespace HISTORY
       public:
 
         HistorySubMenu( const std::string& url_history );
-        virtual ~HistorySubMenu();
+        ~HistorySubMenu();
 
         // 履歴の先頭を復元
         void restore_history();

--- a/src/image/imageadmin.h
+++ b/src/image/imageadmin.h
@@ -38,60 +38,60 @@ namespace IMAGE
         ImageAdmin( const std::string& url );
         ~ImageAdmin();
 
-        virtual void save_session();
+        void save_session() override;
 
         Gtk::HBox& tab() { return m_tab; }
-        virtual Gtk::Widget* get_widget() { return &m_view; }
+        Gtk::Widget* get_widget() override { return &m_view; }
 
-        virtual bool empty();
-        virtual void clock_in();
+        bool empty() override;
+        void clock_in() override;
 
         // タブの数
-        virtual int get_tab_nums();
+        int get_tab_nums() override;
 
         // 含まれているページのURLのリスト取得
-        virtual const std::list< std::string > get_URLs();
+        const std::list< std::string > get_URLs() override;
 
         // 現在表示してるページ番号
-        virtual int get_current_page();
+        int get_current_page() override;
 
       protected:
 
-        virtual void command_local( const COMMAND_ARGS& command );
+        void command_local( const COMMAND_ARGS& command ) override;
 
-        virtual void restore( const bool only_locked );
-        virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock );
+        void restore( const bool only_locked ) override;
+        COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override;
 
-        virtual void switch_admin();
-        virtual void open_view( const COMMAND_ARGS& command );
-        virtual void tab_left( const bool updated );
-        virtual void tab_right( const bool updatd );
-        virtual void tab_head();
-        virtual void tab_tail();
-        virtual void redraw_view( const std::string& url );
-        virtual void redraw_current_view();
-        virtual void close_view( const std::string& url );
-        virtual void close_other_views( const std::string& url );
-        virtual void restore_lasttab();
-        virtual void focus_view( int page );
-        virtual void focus_current_view();
-        virtual void open_window();
-        virtual void close_window();
+        void switch_admin() override;
+        void open_view( const COMMAND_ARGS& command ) override;
+        void tab_left( const bool updated ) override;
+        void tab_right( const bool updatd ) override;
+        void tab_head() override;
+        void tab_tail() override;
+        void redraw_view( const std::string& url ) override;
+        void redraw_current_view() override;
+        void close_view( const std::string& url ) override;
+        void close_other_views( const std::string& url ) override;
+        void restore_lasttab() override;
+        void focus_view( int page ) override;
+        void focus_current_view() override;
+        void open_window() override;
+        void close_window() override;
 
-        virtual SKELETON::View* get_view( const std::string& url );
-        virtual SKELETON::View* get_current_view();
+        SKELETON::View* get_view( const std::string& url ) override;
+        SKELETON::View* get_current_view() override;
 
         // ページがロックされているかリストで取得
-        virtual std::list< bool > get_locked();
+        std::list< bool > get_locked() override;
 
         // タブのロック/アンロック
-        virtual const bool is_lockable( const int page );
-        virtual const bool is_locked( const int page );
-        virtual void lock( const int page );
-        virtual void unlock( const int page );
+        const bool is_lockable( const int page ) override;
+        const bool is_locked( const int page ) override;
+        void lock( const int page ) override;
+        void unlock( const int page ) override;
 
         // タブの D&D 処理は SKELETON::Admin とは違うロジックでおこなう
-        virtual void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ){}
+        void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override {}
 
       private:
 

--- a/src/image/imagearea.h
+++ b/src/image/imagearea.h
@@ -16,9 +16,9 @@ namespace IMAGE
       public:
 
         ImageAreaMain( const std::string& url );
-        virtual ~ImageAreaMain();
+        ~ImageAreaMain();
 
-        virtual void show_image();
+        void show_image() override;
     };
 }
 

--- a/src/image/imageareabase.h
+++ b/src/image/imageareabase.h
@@ -49,7 +49,7 @@ namespace IMAGE
         // 1 -> INTERP_BILINEAR
         // 3 -> INTERP_HYPER
         ImageAreaBase( const std::string& url, const int interptype );
-        virtual ~ImageAreaBase();
+        ~ImageAreaBase();
 
         void stop();
         void wait();
@@ -84,7 +84,7 @@ namespace IMAGE
 
     private:
 
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
         virtual void set_image();
         void set_mosaic( Glib::RefPtr< Gdk::Pixbuf > pixbuf );
     };

--- a/src/image/imageareaicon.h
+++ b/src/image/imageareaicon.h
@@ -32,11 +32,11 @@ namespace IMAGE
       public:
 
         ImageAreaIcon( const std::string& url );
-        virtual ~ImageAreaIcon();
+        ~ImageAreaIcon();
 
-        virtual void show_image();
+        void show_image() override;
 
-        virtual void load_image_thread();
+        void load_image_thread() override;
 
       private:
 
@@ -45,7 +45,7 @@ namespace IMAGE
 
         void show_indicator( bool loading );
 
-        virtual void set_image();
+        void set_image() override;
     };
 }
 

--- a/src/image/imageareapopup.h
+++ b/src/image/imageareapopup.h
@@ -16,9 +16,9 @@ namespace IMAGE
       public:
 
         ImageAreaPopup( const std::string& url );
-        virtual ~ImageAreaPopup();
+        ~ImageAreaPopup();
         
-        virtual void show_image();
+        void show_image() override;
     };
 }
 

--- a/src/image/imageview.h
+++ b/src/image/imageview.h
@@ -33,31 +33,31 @@ namespace IMAGE
 
       public:
         ImageViewMain( const std::string& url );
-        virtual ~ImageViewMain();
+        ~ImageViewMain();
 
-        virtual void clock_in();
-        virtual void show_view();
-        virtual void scroll_up();
-        virtual void scroll_down();
-        virtual void scroll_left();
-        virtual void scroll_right();
+        void clock_in() override;
+        void show_view() override;
+        void scroll_up() override;
+        void scroll_down() override;
+        void scroll_left() override;
+        void scroll_right() override;
 
-        virtual const bool operate_view( const int control );
+        const bool operate_view( const int control ) override;
 
       protected:
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
 
-        virtual bool slot_button_press( GdkEventButton* event );
-        virtual bool slot_motion_notify( GdkEventMotion* event );
+        bool slot_button_press( GdkEventButton* event ) override;
+        bool slot_motion_notify( GdkEventMotion* event ) override;
 
       private:
 
         void set_status_local( const std::string& status ){ m_status_local = status; }
         const std::string& get_status_local(){ return m_status_local; }
 
-        virtual void show_status();
-        virtual void update_status();
+        void show_status() override;
+        void update_status() override;
         void add_tab_number();
 
         void show_instruct_diag();

--- a/src/image/imageviewbase.h
+++ b/src/image/imageviewbase.h
@@ -51,7 +51,7 @@ namespace IMAGE
       protected:
 
         // Viewが所属するAdminクラス
-        virtual SKELETON::Admin* get_admin();
+        SKELETON::Admin* get_admin() override;
 
         JDLIB::ConstPtr< DBIMG::Img >& get_img(){ return  m_img;}
 
@@ -62,7 +62,7 @@ namespace IMAGE
         const bool is_wait() const{ return m_wait; }
         void set_wait( const bool wait ){ m_wait = wait; }
 
-        const bool is_loading() const{ return m_loading; }
+        const bool is_loading() const override { return m_loading; }
         void set_loading( const bool loading ){ m_loading = loading; }
 
         Gtk::EventBox& get_event(){ return  m_event; }
@@ -70,7 +70,7 @@ namespace IMAGE
       public:
 
         ImageViewBase( const std::string& url, const std::string& arg1 = std::string(), const std::string& arg2 = std::string() );
-        virtual ~ImageViewBase();
+        ~ImageViewBase();
 
         const bool is_under_mouse() const { return m_under_mouse; }
 
@@ -78,34 +78,33 @@ namespace IMAGE
         // SKELETON::View の関数のオーバロード
         //
 
-        virtual void save_session(){}
+        void save_session() override {}
 
         // 親ウィンドウを取得
-        virtual Gtk::Window* get_parent_win();
+        Gtk::Window* get_parent_win() override;
 
         // キーを押した
-        virtual const bool slot_key_press( GdkEventKey* event );
+        const bool slot_key_press( GdkEventKey* event ) override;
 
         // コマンド
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
-        virtual void reload();
-        virtual void stop();
-        virtual void redraw_view();
-        virtual void close_view();
-        virtual void delete_view();
-        virtual const bool operate_view( const int control );
-        virtual void show_preference();
+        void reload() override;
+        void stop() override;
+        void redraw_view() override;
+        void close_view() override;
+        void delete_view() override;
+        const bool operate_view( const int control ) override;
+        void show_preference() override;
 
       protected:
 
         void setup_common();
         void set_image_to_buffer();
 
-        virtual void activate_act_before_popupmenu( const std::string& url );
+        void activate_act_before_popupmenu( const std::string& url ) override;
 
         void delete_view_impl( const bool show_diag );
         void slot_cancel_mosaic();

--- a/src/image/imageviewicon.h
+++ b/src/image/imageviewicon.h
@@ -17,21 +17,21 @@ namespace IMAGE
 
       public:
         ImageViewIcon( const std::string& url );
-        virtual ~ImageViewIcon();
+        ~ImageViewIcon();
 
-        virtual void clock_in();
-        virtual void focus_view();
-        virtual void focus_out();
-        virtual void show_view();
+        void clock_in() override;
+        void focus_view() override;
+        void focus_out() override;
+        void show_view() override;
 
       protected:
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
-        virtual bool slot_scroll_event( GdkEventScroll* event );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
+        bool slot_scroll_event( GdkEventScroll* event ) override;
 
       private:
 
-        virtual void switch_icon();
+        void switch_icon() override;
 
         void slot_drag_begin( const Glib::RefPtr<Gdk::DragContext>& context );
         void slot_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -23,28 +23,28 @@ namespace IMAGE
       public:
 
         ImageViewPopup( const std::string& url );
-        virtual ~ImageViewPopup();
+        ~ImageViewPopup();
 
-        virtual void clock_in();
+        void clock_in() override;
 
         // 親ウィンドウは無し
-        virtual Gtk::Window* get_parent_win(){ return NULL; }
+        Gtk::Window* get_parent_win() override { return nullptr; }
 
-        virtual void stop();
-        virtual void show_view();
-        virtual void close_view();
-        virtual const bool operate_view( const int control );
+        void stop() override;
+        void show_view() override;
+        void close_view() override;
+        const bool operate_view( const int control ) override;
 
       protected:
 
-        virtual Gtk::Menu* get_popupmenu( const std::string& url );
+        Gtk::Menu* get_popupmenu( const std::string& url ) override;
 
       private:
 
         void show_view_impl();
 
         // クリックした時の処理
-        virtual void clicked();
+        void clicked() override;
 
         void update_label();
         void set_label( const std::string& status );

--- a/src/image/imagewin.h
+++ b/src/image/imagewin.h
@@ -20,38 +20,38 @@ namespace IMAGE
       public:
 
         ImageWin();
-        virtual ~ImageWin();
+        ~ImageWin();
 
         void pack_remove_tab( bool unpack, Widget& tab );
 
       protected:
 
-        virtual void switch_admin();
+        void switch_admin() override;
 
-        virtual const int get_x_win();
-        virtual const int get_y_win();
-        virtual void set_x_win( const int x );
-        virtual void set_y_win( const int y );
+        const int get_x_win() override;
+        const int get_y_win() override;
+        void set_x_win( const int x ) override;
+        void set_y_win( const int y ) override;
 
-        virtual const int get_width_win();
-        virtual const int get_height_win();
-        virtual void set_width_win( const int width );
-        virtual void set_height_win( const int height );
+        const int get_width_win() override;
+        const int get_height_win() override;
+        void set_width_win( const int width ) override;
+        void set_height_win( const int height ) override;
 
-        virtual const bool is_focus_win();
-        virtual void set_focus_win( const bool set );
+        const bool is_focus_win() override;
+        void set_focus_win( const bool set ) override;
 
-        virtual const bool is_maximized_win();
-        virtual void set_maximized_win( const bool set );
+        const bool is_maximized_win() override;
+        void set_maximized_win( const bool set ) override;
 
-        virtual const bool is_iconified_win();
-        virtual void set_iconified_win( const bool set );
+        const bool is_iconified_win() override;
+        void set_iconified_win( const bool set ) override;
 
-        virtual const bool is_full_win(){ return false; }
-        virtual void set_full_win( const bool set ){}
+        const bool is_full_win() override { return false; }
+        void set_full_win( const bool set ) override {}
 
-        virtual const bool is_shown_win();
-        virtual void set_shown_win( const bool set );
+        const bool is_shown_win() override;
+        void set_shown_win( const bool set ) override;
     };
 }
 

--- a/src/image/preference.h
+++ b/src/image/preference.h
@@ -32,7 +32,7 @@ namespace IMAGE
         Preferences( Gtk::Window* parent, const std::string& url );
 
       private:
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
         void slot_open_ref();
     };
 

--- a/src/jdlib/imgloader.h
+++ b/src/jdlib/imgloader.h
@@ -69,7 +69,7 @@ namespace JDLIB
         JDLIB::Mutex m_provider_lock; // ImgProvider操作時の必須ロック
         
     public:
-        virtual ~ImgProvider(){}
+        virtual ~ImgProvider() noexcept {}
         static ImgProvider& get_provider();
         
         Glib::RefPtr< ImgLoader > get_loader( const std::string& file );

--- a/src/jdlib/misctrip.cpp
+++ b/src/jdlib/misctrip.cpp
@@ -80,7 +80,7 @@ const std::string create_sha1( const std::string& key )
         sha1 << digest[n];
 
 #ifdef _DEBUG
-        std::cout << std::hex << (unsigned int)digest[n];
+        std::cout << std::hex << (unsigned int)digest[n] << std::dec;
 #endif
     }
 

--- a/src/linkfiltermanager.h
+++ b/src/linkfiltermanager.h
@@ -26,7 +26,7 @@ namespace CORE
     public:
 
         Linkfilter_Manager();
-        virtual ~Linkfilter_Manager(){}
+        virtual ~Linkfilter_Manager() noexcept {}
 
         std::vector< LinkFilterItem >& get_list(){ return  m_list_cmd; }
         void save_xml();

--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -85,7 +85,7 @@ namespace CORE
         void select_row( const Gtk::TreeModel::iterator& row );
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         void slot_row_activated( const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column );
         bool slot_key_release( GdkEventKey* event );

--- a/src/livepref.h
+++ b/src/livepref.h
@@ -35,12 +35,12 @@ namespace CORE
       public:
 
         LivePref( Gtk::Window* parent, const std::string& url );
-        virtual ~LivePref(){}
+        ~LivePref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         void slot_reset();
     };

--- a/src/login2ch.h
+++ b/src/login2ch.h
@@ -21,15 +21,15 @@ namespace CORE
       public:
 
         Login2ch();
-        virtual ~Login2ch();
+        ~Login2ch();
 
-        virtual void start_login();
-        virtual void logout();
+        void start_login() override;
+        void logout() override;
 
       private:
 
-        virtual void receive_data( const char* , size_t );
-        virtual void receive_finish();
+        void receive_data( const char* , size_t ) override;
+        void receive_finish() override;
     };
 
 

--- a/src/loginbe.h
+++ b/src/loginbe.h
@@ -21,15 +21,15 @@ namespace CORE
       public:
 
         LoginBe();
-        virtual ~LoginBe();
+        ~LoginBe();
 
-        virtual void start_login();
-        virtual void logout();
+        void start_login() override;
+        void logout() override;
 
       private:
 
-        virtual void receive_data( const char* , size_t );
-        virtual void receive_finish();
+        void receive_data( const char* , size_t ) override;
+        void receive_finish() override;
     };
 
 

--- a/src/loginp2.h
+++ b/src/loginp2.h
@@ -23,15 +23,15 @@ namespace CORE
       public:
 
         Loginp2();
-        virtual ~Loginp2();
+        ~Loginp2();
 
-        virtual void start_login();
-        virtual void logout();
+        void start_login() override;
+        void logout() override;
 
       private:
 
-        virtual void receive_data( const char* , size_t );
-        virtual void receive_finish();
+        void receive_data( const char* , size_t ) override;
+        void receive_finish() override;
     };
 
 

--- a/src/mainitempref.h
+++ b/src/mainitempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         MainItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~MainItemPref(){}
+        ~MainItemPref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/maintoolbar.h
+++ b/src/maintoolbar.h
@@ -41,11 +41,11 @@ namespace CORE
       public:
 
         MainToolBar(); 
-        virtual ~MainToolBar(){}
+        ~MainToolBar() noexcept {}
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
     };
 }
 

--- a/src/message/confirmdiag.h
+++ b/src/message/confirmdiag.h
@@ -23,7 +23,7 @@ namespace MESSAGE
 
       private:
 
-        virtual void slot_switch_page( GtkNotebookPage*, guint page );
+        void slot_switch_page( GtkNotebookPage*, guint page ) override;
     };
 }
 

--- a/src/message/messageadmin.h
+++ b/src/message/messageadmin.h
@@ -42,9 +42,9 @@ namespace MESSAGE
       public:
 
         MessageAdmin( const std::string& url );
-        virtual ~MessageAdmin();
+        ~MessageAdmin();
 
-        virtual void save_session(){}
+        void save_session() override {}
 
         void show_entry_new_subject( bool show );
         std::string get_new_subject();
@@ -53,34 +53,35 @@ namespace MESSAGE
 
       protected:
 
-        virtual void set_status( const std::string& url, const std::string& stat, const bool force );
+        void set_status( const std::string& url, const std::string& stat, const bool force ) override;
 
         // ツールバー
-        virtual void show_toolbar();
+        void show_toolbar() override;
 
-        virtual void command_local( const COMMAND_ARGS& command );
+        void command_local( const COMMAND_ARGS& command ) override;
 
       private:
 
         const bool delete_message( SKELETON::View * view );
 
         // 復元をしない
-        virtual void restore( const bool only_locked ){}
-        virtual COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ){
+        void restore( const bool only_locked ) override {}
+        COMMAND_ARGS url_to_openarg( const std::string& url, const bool tab, const bool lock ) override
+        {
             COMMAND_ARGS ret;
             return ret;
         }
 
-        virtual void open_view( const COMMAND_ARGS& command );
-        virtual void switch_admin();
-        virtual void tab_left( const bool updated );
-        virtual void tab_right( const bool updated );
-        virtual void close_view( const std::string& url );
-        virtual void open_window();
-        virtual void close_window();
+        void open_view( const COMMAND_ARGS& command ) override;
+        void switch_admin() override;
+        void tab_left( const bool updated ) override;
+        void tab_right( const bool updated ) override;
+        void close_view( const std::string& url ) override;
+        void open_window() override;
+        void close_window() override;
 
         // タブの D&D 処理をしない
-        virtual void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ){}
+        void slot_drag_data_get( Gtk::SelectionData& selection_data, const int page ) override {}
     };
     
     MESSAGE::MessageAdmin* get_admin();

--- a/src/message/messageview.h
+++ b/src/message/messageview.h
@@ -12,13 +12,13 @@ namespace MESSAGE
     {
       public:
         MessageViewMain( const std::string& url, const std::string& msg );
-        virtual ~MessageViewMain();
+        ~MessageViewMain();
 
-        virtual void reload();
+        void reload() override;
 
       private:
-        virtual void write_impl( const std::string& msg );
-        virtual const std::string create_message();
+        void write_impl( const std::string& msg ) override;
+        const std::string create_message() override;
     };
 
 
@@ -27,17 +27,16 @@ namespace MESSAGE
     {
       public:
         MessageViewNew( const std::string& url, const std::string& msg );
-        virtual ~MessageViewNew(){}
+        ~MessageViewNew() noexcept {}
 
-        virtual void reload();
+        void reload() override;
 
       private:
-        virtual void write_impl( const std::string& msg );
-        virtual const std::string create_message();
+        void write_impl( const std::string& msg ) override;
+        const std::string create_message() override;
     };
 
 }
 
-    
 
 #endif

--- a/src/message/messageviewbase.h
+++ b/src/message/messageviewbase.h
@@ -79,43 +79,42 @@ namespace MESSAGE
       public:
 
         MessageViewBase( const std::string& url );
-        virtual ~MessageViewBase();
+        ~MessageViewBase();
 
         //
         // SKELETON::View の関数のオーバロード
         //
 
-        virtual void save_session(){}
+        void save_session() override {}
 
         // 親ウィンドウを取得
-        virtual Gtk::Window* get_parent_win();
+        Gtk::Window* get_parent_win() override;
 
         // コピー用のURL
-        virtual const std::string url_for_copy();
+        const std::string url_for_copy() override;
 
         // コマンド
-        virtual const bool set_command( const std::string& command,
-                                        const std::string& arg1 = std::string(),
-                                        const std::string& arg2 = std::string()
-            );
+        const bool set_command( const std::string& command,
+                                const std::string& arg1 = {},
+                                const std::string& arg2 = {} ) override;
 
         // ロード中
-        virtual const bool is_loading() const;
+        const bool is_loading() const override;
 
         // 規制中や行数や文字列がオーバーして書き込めない
-        virtual const bool is_broken(){ return ( ! m_str_pass.empty() || m_over_lines || m_over_lng ); }
+        const bool is_broken() override { return ( ! m_str_pass.empty() || m_over_lines || m_over_lng ); }
 
         // キーを押した        
-        virtual const bool slot_key_press( GdkEventKey* event );
+        const bool slot_key_press( GdkEventKey* event ) override;
 
-        virtual void clock_in();
-        virtual void write();
-        virtual void reload(){}
-        virtual void relayout();
-        virtual void close_view();
-        virtual void redraw_view();
-        virtual void focus_view();
-        virtual const bool operate_view( const int control );
+        void clock_in() override;
+        void write() override;
+        void reload() override {}
+        void relayout() override;
+        void close_view() override;
+        void redraw_view() override;
+        void focus_view() override;
+        const bool operate_view( const int control ) override;
 
       private:
 
@@ -160,7 +159,7 @@ namespace MESSAGE
       protected:
 
         // Viewが所属するAdminクラス
-        virtual SKELETON::Admin* get_admin();
+        SKELETON::Admin* get_admin() override;
 
         void set_message( const std::string& msg );
         const Glib::ustring get_message();

--- a/src/message/messagewin.h
+++ b/src/message/messagewin.h
@@ -14,38 +14,38 @@ namespace MESSAGE
       public:
 
         MessageWin();
-        virtual ~MessageWin();
+        ~MessageWin();
 
       protected:
 
-        virtual void switch_admin();
+        void switch_admin() override;
 
-        virtual const int get_x_win();
-        virtual const int get_y_win();
-        virtual void set_x_win( const int x );
-        virtual void set_y_win( const int y );
+        const int get_x_win() override;
+        const int get_y_win() override;
+        void set_x_win( const int x ) override;
+        void set_y_win( const int y ) override;
 
-        virtual const int get_width_win();
-        virtual const int get_height_win();
-        virtual void set_width_win( const int width );
-        virtual void set_height_win( const int height );
+        const int get_width_win() override;
+        const int get_height_win() override;
+        void set_width_win( const int width ) override;
+        void set_height_win( const int height ) override;
 
-        virtual const bool is_focus_win();
-        virtual void set_focus_win( const bool set );
+        const bool is_focus_win() override;
+        void set_focus_win( const bool set ) override;
 
-        virtual const bool is_maximized_win();
-        virtual void set_maximized_win( const bool set );
+        const bool is_maximized_win() override;
+        void set_maximized_win( const bool set ) override;
 
-        virtual const bool is_iconified_win();
-        virtual void set_iconified_win( const bool set );
+        const bool is_iconified_win() override;
+        void set_iconified_win( const bool set ) override;
 
-        virtual const bool is_full_win(){ return false; }
-        virtual void set_full_win( const bool set ){}
+        const bool is_full_win() override { return false; }
+        void set_full_win( const bool ) override {}
 
-        virtual const bool is_shown_win();
-        virtual void set_shown_win( const bool set );
+        const bool is_shown_win() override;
+        void set_shown_win( const bool set ) override;
 
-        virtual bool on_delete_event( GdkEventAny* event );
+        bool on_delete_event( GdkEventAny* event ) override;
     };
 }
 

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -62,8 +62,8 @@ namespace MESSAGE
         void emit_sigfin();
         void slot_response( int id );
 
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
     };
     
 }

--- a/src/message/toolbar.h
+++ b/src/message/toolbar.h
@@ -28,7 +28,7 @@ namespace MESSAGE
       public:
 
         MessageToolBarBase();
-        virtual ~MessageToolBarBase(){}
+        ~MessageToolBarBase() noexcept {}
 
         // previewボタンのトグル
         void set_active_previewbutton( const bool active );
@@ -59,7 +59,7 @@ namespace MESSAGE
       public:
 
         MessageToolBar();
-        virtual ~MessageToolBar(){}
+        ~MessageToolBar() noexcept {}
 
         void show_entry_new_subject( bool show );
         std::string get_new_subject();
@@ -67,7 +67,7 @@ namespace MESSAGE
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
 
       private:
 
@@ -83,11 +83,11 @@ namespace MESSAGE
       public:
 
         MessageToolBarPreview();
-        virtual ~MessageToolBarPreview(){}
+        ~MessageToolBarPreview() noexcept {}
 
       protected:
 
-        virtual void pack_buttons();
+        void pack_buttons() override;
     };
 }
 

--- a/src/msgitempref.h
+++ b/src/msgitempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         MsgItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~MsgItemPref(){}
+        ~MsgItemPref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/openurldiag.h
+++ b/src/openurldiag.h
@@ -19,11 +19,11 @@ namespace CORE
       public:
 
         OpenURLDialog( const std::string& url );
-        virtual ~OpenURLDialog(){}
+        ~OpenURLDialog() noexcept {}
 
       protected:
 
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
     };
 }
 

--- a/src/passwdpref.h
+++ b/src/passwdpref.h
@@ -125,8 +125,8 @@ namespace CORE
         PasswdFramep2 m_frame_p2;
 
         // OK押した
-        virtual void slot_ok_clicked(){
-
+        void slot_ok_clicked() override
+        {
             // 2ch
             CORE::get_login2ch()->set_username( MISC::remove_space( m_frame_2ch.entry_id.get_text() ) );
             CORE::get_login2ch()->set_passwd( MISC::remove_space( m_frame_2ch.entry_passwd.get_text() ) );
@@ -176,7 +176,7 @@ namespace CORE
             show_all_children();
         }
 
-        virtual ~PasswdPref(){}
+        ~PasswdPref() noexcept {}
     };
 
 }

--- a/src/privacypref.h
+++ b/src/privacypref.h
@@ -36,7 +36,7 @@ namespace CORE
         }
 
         // OK押した
-        virtual void slot_ok_clicked()
+        void slot_ok_clicked() override
         {
             if( m_bt_board.get_active() ) CORE::core_set_command( "clear_board" );
             if( m_bt_thread.get_active() ) CORE::core_set_command( "clear_thread" );
@@ -78,7 +78,7 @@ namespace CORE
             show_all_children();
         }
 
-        virtual ~PrivacyPref(){}
+        ~PrivacyPref() noexcept {}
     };
 
 }

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -57,8 +57,8 @@ namespace CORE
         ProxyFrame m_frame_data;
 
         // OK押した
-        virtual void slot_ok_clicked(){
-
+        void slot_ok_clicked() override
+        {
             // 2ch
             if( m_frame_2ch.ckbt.get_active() ) CONFIG::set_use_proxy_for2ch( true );
             else CONFIG::set_use_proxy_for2ch( false );
@@ -132,7 +132,7 @@ namespace CORE
             show_all_children();
         }
 
-        virtual ~ProxyPref(){}
+        ~ProxyPref() noexcept {}
     };
 
 }

--- a/src/searchitempref.h
+++ b/src/searchitempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         SearchItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~SearchItemPref(){}
+        ~SearchItemPref() noexcept {}
 
       private:
 
         // OKボタン
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/searchloader.h
+++ b/src/searchloader.h
@@ -33,15 +33,15 @@ namespace CORE
 
       protected:
 
-        virtual const std::string get_url();
-        virtual const std::string get_path(){ return std::string(); }
-        virtual const std::string get_charset(){ return m_charset; }
+        const std::string get_url() override;
+        const std::string get_path() override { return {}; }
+        const std::string get_charset() override { return m_charset; }
 
         // ロード用データ作成
-        virtual void create_loaderdata( JDLIB::LOADERDATA& data );
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
 
         // ロード後に呼び出される
-        virtual void parse_data();
+        void parse_data() override;
     };
 }
 

--- a/src/searchmanager.h
+++ b/src/searchmanager.h
@@ -73,7 +73,7 @@ namespace CORE
       public:
 
         Search_Manager();
-        virtual ~Search_Manager();
+        ~Search_Manager();
 
         SIG_SEARCH_FIN sig_search_fin(){ return m_sig_search_fin; }
 
@@ -109,7 +109,7 @@ namespace CORE
         static void* launcher( void* );
         void wait();
         void thread_search();
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
         void search_fin();
         void search_fin_title();
     };

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -154,7 +154,7 @@ namespace CORE
 
       public:
         SetupWizard();
-        virtual ~SetupWizard();
+        ~SetupWizard();
 
       private:
         void slot_switch_page( GtkNotebookPage* notebookpage, guint page );

--- a/src/sidebaritempref.h
+++ b/src/sidebaritempref.h
@@ -14,15 +14,15 @@ namespace CORE
       public:
 
         SidebarItemPref( Gtk::Window* parent, const std::string& url  );
-        virtual ~SidebarItemPref(){}
+        ~SidebarItemPref() noexcept {}
 
       private:
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         // デフォルトボタン
-        virtual void slot_default();
+        void slot_default() override;
     };
 }
 

--- a/src/skeleton/aamenu.h
+++ b/src/skeleton/aamenu.h
@@ -31,16 +31,16 @@ namespace SKELETON
       public:
 
         AAMenu( Gtk::Window& parent );
-        virtual ~AAMenu();
+        ~AAMenu();
 
         // 選択されたらemitされる
         SIG_AAMENU_SELECTED sig_selected() { return m_sig_selected; }
 
       protected:
 
-        virtual void on_map();
-        virtual void on_hide();
-        virtual bool on_key_press_event (GdkEventKey* event);
+        void on_map() override;
+        void on_hide() override;
+        bool on_key_press_event (GdkEventKey* event) override;
 
       private:
 

--- a/src/skeleton/admin.h
+++ b/src/skeleton/admin.h
@@ -59,7 +59,7 @@ namespace SKELETON
     public:
 
         Admin( const std::string& url );
-        virtual ~Admin();
+        ~Admin();
 
         virtual void save_session();
 
@@ -155,7 +155,7 @@ namespace SKELETON
         // immediately = true のときディスパッチャを呼ばずにすぐさま実行
         void set_command_impl( const bool immediately, const COMMAND_ARGS& command_arg );
 
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
 
         // admin共通コマンド実行
         virtual void exec_command();

--- a/src/skeleton/backforwardbutton.h
+++ b/src/skeleton/backforwardbutton.h
@@ -23,7 +23,7 @@ namespace SKELETON
       protected:
 
       // ポップアップメニュー表示
-      virtual void show_popupmenu();
+      void show_popupmenu() override;
     };
 }
 

--- a/src/skeleton/compentry.cpp
+++ b/src/skeleton/compentry.cpp
@@ -51,7 +51,7 @@ CompletionEntry::CompletionEntry( const int mode )
 }
 
 
-CompletionEntry::~CompletionEntry()
+CompletionEntry::~CompletionEntry() noexcept
 {}
 
 

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -44,7 +44,7 @@ namespace SKELETON
 
         // mode は補完モード ( compmanager.h 参照 )
         CompletionEntry( const int mode );
-        virtual ~CompletionEntry();
+        ~CompletionEntry() noexcept;
 
         SIG_OPERATE signal_operate(){ return m_sig_operate; }
         SIG_ACTIVATE signal_activate(){ return m_sig_activate; }

--- a/src/skeleton/detaildiag.h
+++ b/src/skeleton/detaildiag.h
@@ -24,7 +24,7 @@ namespace SKELETON
                     const std::string& message, const std::string& tab_message,
                     const std::string& detail_html, const std::string& tab_detail
             );
-        virtual ~DetailDiag();
+        ~DetailDiag();
 
       protected:
 
@@ -34,7 +34,7 @@ namespace SKELETON
       private:
 
         virtual void slot_switch_page( GtkNotebookPage*, guint page );
-        virtual void timeout();
+        void timeout() override;
     };
 }
 

--- a/src/skeleton/dragnote.h
+++ b/src/skeleton/dragnote.h
@@ -114,7 +114,7 @@ namespace SKELETON
         SIG_DRAG_DATA_GET sig_drag_data_get() { return m_sig_drag_data_get; }
 
         DragableNoteBook();
-        virtual ~DragableNoteBook();
+        ~DragableNoteBook();
 
         void clock_in();
         void focus_out();
@@ -168,7 +168,7 @@ namespace SKELETON
 
       private:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
 
         // DragableNoteBook を構成している各Notebookの高さ
         // 及びタブの高さと位置を取得 ( 枠の描画用 )

--- a/src/skeleton/dragtreeview.h
+++ b/src/skeleton/dragtreeview.h
@@ -62,7 +62,7 @@ namespace SKELETON
         // use_usr_fontcolor が true の時はフォントや色を指定する
         DragTreeView( const std::string& url, const std::string& dndtarget,
                       const bool use_usr_fontcolor, const std::string& fontname, const int colorid_text, const int colorid_bg, const int colorid_bg_even );
-        virtual ~DragTreeView();
+        ~DragTreeView();
 
         virtual void clock_in();
 
@@ -114,19 +114,19 @@ namespace SKELETON
         // drag_source_set() でセットしたボタン以外でドラッグしたときは on_drag_motion()
         // ではなくて普通に on_motion_notify_event() が呼ばれるのに注意
         //
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
-        virtual void on_drag_begin( const Glib::RefPtr< Gdk::DragContext>& context );
-        virtual void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context );
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
+        void on_drag_begin( const Glib::RefPtr< Gdk::DragContext>& context ) override;
+        void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context ) override;
 
-        virtual void on_drag_data_received( const Glib::RefPtr< Gdk::DragContext >& context, int x, int y, 
-                                            const Gtk::SelectionData& selection, guint info, guint time );
+        void on_drag_data_received( const Glib::RefPtr< Gdk::DragContext >& context, int x, int y,
+                                    const Gtk::SelectionData& selection, guint info, guint time ) override;
 
-        virtual bool on_key_press_event( GdkEventKey* event );
+        bool on_key_press_event( GdkEventKey* event ) override;
 
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
-        virtual bool on_scroll_event( GdkEventScroll* event );
-        virtual bool on_leave_notify_event( GdkEventCrossing* event );
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
+        bool on_scroll_event( GdkEventScroll* event ) override;
+        bool on_leave_notify_event( GdkEventCrossing* event ) override;
 
       private:
 

--- a/src/skeleton/editcolumns.h
+++ b/src/skeleton/editcolumns.h
@@ -49,7 +49,7 @@ namespace SKELETON
         Gtk::TreeModelColumn< size_t > m_dirid; // ディレクトリID
 
         EditColumns();
-        virtual ~EditColumns();
+        ~EditColumns();
 
         virtual void setup_row( Gtk::TreeModel::Row& row,
                                 const Glib::ustring url, const Glib::ustring name, const Glib::ustring data, const int type, const size_t dirid );

--- a/src/skeleton/edittreeview.h
+++ b/src/skeleton/edittreeview.h
@@ -86,9 +86,9 @@ namespace SKELETON
 
         EditTreeView( const std::string& url, const std::string& dndtarget, EditColumns& columns );
 
-        virtual ~EditTreeView();
+        ~EditTreeView();
 
-        virtual void clock_in();
+        void clock_in() override;
 
         SIG_DROPPED_FROM_OTHER sig_dropped_from_other(){ return m_sig_dropped_from_other; }
 
@@ -167,7 +167,7 @@ namespace SKELETON
 
         // 選択した行をまとめて削除
         // force = true なら m_editable が false でも削除
-        virtual void delete_selected_rows( const bool force );
+        void delete_selected_rows( const bool force ) override;
 
         void undo();
         void redo();
@@ -190,15 +190,15 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time );
-        virtual void on_drag_leave( const Glib::RefPtr<Gdk::DragContext>& context, guint time );
-        virtual bool on_drag_drop( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time );
-        virtual void on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
-                                       Gtk::SelectionData& selection_data, guint info, guint time );
-        virtual void on_drag_data_received( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y,
-                                            const Gtk::SelectionData& selection_data, guint info, guint time );
-        virtual void on_drag_data_delete( const Glib::RefPtr<Gdk::DragContext>& context );
-        virtual void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context );
+        bool on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time ) override;
+        void on_drag_leave( const Glib::RefPtr< Gdk::DragContext >& context, guint time ) override;
+        bool on_drag_drop( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time ) override;
+        void on_drag_data_get( const Glib::RefPtr< Gdk::DragContext >& context,
+                               Gtk::SelectionData& selection_data, guint info, guint time ) override;
+        void on_drag_data_received( const Glib::RefPtr< Gdk::DragContext >& context, int x, int y,
+                                    const Gtk::SelectionData& selection_data, guint info, guint time ) override;
+        void on_drag_data_delete( const Glib::RefPtr<Gdk::DragContext>& context ) override;
+        void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context ) override;
 
       private:
 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -61,7 +61,7 @@ namespace SKELETON
         SIG_BUTTON_PRESS sig_button_press() { return m_sig_button_press; }
 
         EditTextView();
-        virtual ~EditTextView();
+        ~EditTextView();
 
         void insert_str( const std::string& str, bool use_br );
 
@@ -83,12 +83,12 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_button_press_event( GdkEventButton* event );
+        bool on_button_press_event( GdkEventButton* event ) override;
 
-        virtual bool on_key_press_event( GdkEventKey* event );
-        virtual bool on_key_release_event( GdkEventKey* event );
+        bool on_key_press_event( GdkEventKey* event ) override;
+        bool on_key_release_event( GdkEventKey* event ) override;
 
-        virtual void on_populate_popup( Gtk::Menu* menu );
+        void on_populate_popup( Gtk::Menu* menu ) override;
 
         void slot_buffer_changed();
 
@@ -131,7 +131,7 @@ namespace SKELETON
 
             show_all_children();
         }
-        virtual ~EditView(){}
+        ~EditView() noexcept {}
 
         SIG_BUTTON_PRESS sig_button_press(){ return m_textview.sig_button_press(); }
         SIG_KEY_PRESS sig_key_press(){ return m_textview.sig_key_press(); }

--- a/src/skeleton/entry.h
+++ b/src/skeleton/entry.h
@@ -33,7 +33,7 @@ namespace SKELETON
         SIG_OPERATE signal_operate(){ return m_sig_operate; }
 
         JDEntry() : Gtk::Entry(){}
-        virtual ~JDEntry(){}
+        ~JDEntry() noexcept {}
 
         // CONTROL::Control のモード設定( controlid.h 参照 )
         // キー入力をフックして JDEntry::on_key_release_event() で SIG_OPERATE をemitする
@@ -42,11 +42,11 @@ namespace SKELETON
       protected:
 
         // マウスクリックのフック
-        virtual bool on_button_press_event( GdkEventButton* event );
+        bool on_button_press_event( GdkEventButton* event ) override;
 
         // キー入力のフック
-        virtual bool on_key_press_event( GdkEventKey* event );
-        virtual bool on_key_release_event( GdkEventKey* event );
+        bool on_key_press_event( GdkEventKey* event ) override;
+        bool on_key_release_event( GdkEventKey* event ) override;
     };
 }
 

--- a/src/skeleton/filediag.h
+++ b/src/skeleton/filediag.h
@@ -45,7 +45,7 @@ namespace SKELETON
             else set_transient_for( *CORE::get_mainwindow() );
         }
 
-        virtual ~FileDiag(){}
+        ~FileDiag() noexcept {}
 
         virtual int run(){
 

--- a/src/skeleton/hpaned.h
+++ b/src/skeleton/hpaned.h
@@ -19,18 +19,18 @@ namespace SKELETON
       public:
 
         JDHPaned( const int fixmode );
-        virtual ~JDHPaned(){}
+        ~JDHPaned() noexcept {}
 
         HPaneControl& get_ctrl(){ return m_pctrl; }
 
       protected:
 
-        virtual void on_realize();
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
-        virtual bool on_enter_notify_event( GdkEventCrossing* event );
-        virtual bool on_leave_notify_event( GdkEventCrossing* event );
+        void on_realize() override;
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
+        bool on_enter_notify_event( GdkEventCrossing* event ) override;
+        bool on_leave_notify_event( GdkEventCrossing* event ) override;
     };
 }
 

--- a/src/skeleton/jdtoolbar.h
+++ b/src/skeleton/jdtoolbar.h
@@ -15,10 +15,10 @@ namespace SKELETON
     class JDToolbar : public Gtk::Toolbar
     {
     public:
-        JDToolbar(){}
+        JDToolbar() noexcept {}
 
     protected:
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
     };
 }
 

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -78,7 +78,7 @@ namespace SKELETON
       public:
 
         Loadable();
-        virtual ~Loadable();
+        ~Loadable();
 
         // HTTPコードなどの完全クリア
         void clear_load_data();
@@ -139,7 +139,7 @@ namespace SKELETON
         virtual void receive_finish(){};
 
         void delete_loader();
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
 
         const int get_loader_code();
         const std::string get_loader_str_code();

--- a/src/skeleton/lockable.h
+++ b/src/skeleton/lockable.h
@@ -20,7 +20,7 @@ namespace SKELETON
 
         Lockable() :m_lock( 0 ){}
         
-        virtual ~Lockable(){}
+        virtual ~Lockable() noexcept {}
 
         const int get_lock() const { return m_lock; }
     

--- a/src/skeleton/login.h
+++ b/src/skeleton/login.h
@@ -28,7 +28,7 @@ namespace SKELETON
       public:
 
         Login( const std::string& url );
-        virtual ~Login();
+        ~Login();
 
         const bool login_now() const { return m_login_now; }
         void set_login_now( bool login_now ){ m_login_now = login_now; }

--- a/src/skeleton/menubutton.h
+++ b/src/skeleton/menubutton.h
@@ -42,7 +42,7 @@ namespace SKELETON
 
         MenuButton( const bool show_arrow , const int id );
 
-      virtual ~MenuButton();
+      ~MenuButton();
 
       Gtk::Widget* get_label_widget(){ return m_label; }
 

--- a/src/skeleton/msgdiag.h
+++ b/src/skeleton/msgdiag.h
@@ -33,7 +33,7 @@ namespace SKELETON
                  Gtk::ButtonsType buttons = Gtk::BUTTONS_OK,
                  bool modal = false);
 
-        virtual ~MsgDiag(){}
+        ~MsgDiag() noexcept {}
 
         void add_default_button( const Gtk::StockID& stock_id, const int id );
         void add_default_button( const Glib::ustring& label, const int id );

--- a/src/skeleton/panecontrol.cpp
+++ b/src/skeleton/panecontrol.cpp
@@ -25,7 +25,7 @@ PaneControl::PaneControl( Gtk::Paned& paned, int fixmode )
 }
 
 
-PaneControl::~PaneControl()
+PaneControl::~PaneControl() noexcept
 {}
 
 

--- a/src/skeleton/panecontrol.h
+++ b/src/skeleton/panecontrol.h
@@ -56,7 +56,7 @@ namespace SKELETON
       public:
 
         PaneControl( Gtk::Paned& paned, int fixmode );
-        virtual ~PaneControl();
+        virtual ~PaneControl() noexcept;
 
         SIG_PANE_MODECHANGED& sig_pane_modechanged() { return m_sig_pane_modechanged; }
 
@@ -100,13 +100,14 @@ namespace SKELETON
       public:
 
         HPaneControl( Gtk::Paned& paned, int fixmode ) : PaneControl( paned, fixmode ) {}
-        ~HPaneControl(){}
+        ~HPaneControl() noexcept {}
 
       protected:
 
-        virtual int get_size(){ return get_paned().get_width(); }
+        int get_size() override { return get_paned().get_width(); }
 
-        virtual bool is_separater_clicked( GdkEventButton* event ){
+        bool is_separater_clicked( GdkEventButton* event ) override
+        {
             if( is_on_paned() && event->type == GDK_BUTTON_PRESS && event->button == 1
                 && event->x >= 0 && event->x <= 8 ) return true;
             return false;
@@ -121,13 +122,14 @@ namespace SKELETON
       public:
 
         VPaneControl( Gtk::Paned& paned, int fixmode ) : PaneControl( paned, fixmode ) {}
-        ~VPaneControl(){}
+        ~VPaneControl() noexcept {}
 
       protected:
 
-        virtual int get_size(){ return get_paned().get_height(); }
+        int get_size() override { return get_paned().get_height(); }
 
-        virtual bool is_separater_clicked( GdkEventButton* event ){
+        bool is_separater_clicked( GdkEventButton* event ) override
+        {
             if( is_on_paned() && event->type == GDK_BUTTON_PRESS && event->button == 1
                 && event->y >= 0 && event->y <= 8 ) return true;
             return false;

--- a/src/skeleton/popupwin.h
+++ b/src/skeleton/popupwin.h
@@ -28,7 +28,7 @@ namespace SKELETON
     public:
 
         PopupWin( Gtk::Widget* parent, SKELETON::View* view, const int mrg_x, const int mrg_y );
-        virtual ~PopupWin();
+        ~PopupWin();
 
         // m_view　からの hide シグナルをブリッジする
         SIG_HIDE_POPUP& sig_hide_popup() { return m_sig_hide_popup; }

--- a/src/skeleton/popupwinbase.h
+++ b/src/skeleton/popupwinbase.h
@@ -36,13 +36,13 @@ namespace SKELETON
         PopupWinBase( bool draw_frame ) : Gtk::Window( Gtk::WINDOW_POPUP ), m_draw_frame( draw_frame ){
             if( m_draw_frame ) set_border_width( 1 );
         }
-        virtual ~PopupWinBase(){}
+        ~PopupWinBase() noexcept {}
 
         SIG_CONFIGURED_POPUP sig_configured(){ return m_sig_configured; }
 
       protected:
 
-        virtual void on_realize()
+        void on_realize() override
         {
             Gtk::Window::on_realize();
 
@@ -50,7 +50,7 @@ namespace SKELETON
             m_gc = Gdk::GC::create( window );    
         }
 
-        virtual bool on_expose_event( GdkEventExpose* event )
+        bool on_expose_event( GdkEventExpose* event ) override
         {
             bool ret = Gtk::Window::on_expose_event( event );
 
@@ -63,7 +63,7 @@ namespace SKELETON
             return ret;
         }
 
-        virtual bool on_configure_event( GdkEventConfigure* event )
+        bool on_configure_event( GdkEventConfigure* event ) override
         {
             bool ret = Gtk::Window::on_configure_event( event );
             m_sig_configured.emit( get_width(), get_height() );

--- a/src/skeleton/prefdiag.h
+++ b/src/skeleton/prefdiag.h
@@ -27,7 +27,7 @@ namespace SKELETON
         // parent == NULL のときはメインウィンドウをparentにする
         PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_cancel = true, const bool add_apply = false, const bool add_open = false );
 
-        virtual ~PrefDiag();
+        ~PrefDiag();
 
         const std::string& get_url() const { return m_url; }
 

--- a/src/skeleton/selectitempref.h
+++ b/src/skeleton/selectitempref.h
@@ -80,7 +80,7 @@ namespace SKELETON
       public:
 
         SelectItemPref( Gtk::Window* parent, const std::string& url );
-        virtual ~SelectItemPref(){}
+        ~SelectItemPref() noexcept {}
 
       private:
 
@@ -119,10 +119,10 @@ namespace SKELETON
         void erase_hidden( const std::string& name );
 
         // KeyPressのフック
-        virtual bool on_key_press_event( GdkEventKey* event );
+        bool on_key_press_event( GdkEventKey* event ) override;
 
         // KeyReleaseのフック
-        virtual bool on_key_release_event( GdkEventKey* event );
+        bool on_key_release_event( GdkEventKey* event ) override;
 
         // 最上位へ移動
         void slot_top();
@@ -146,7 +146,7 @@ namespace SKELETON
         virtual void slot_default() = 0;
 
         // 適用ボタン
-        void slot_apply_clicked(){ slot_ok_clicked(); }
+        void slot_apply_clicked() override { slot_ok_clicked(); }
     };
 }
 

--- a/src/skeleton/spinbutton.h
+++ b/src/skeleton/spinbutton.h
@@ -24,7 +24,8 @@ namespace SKELETON
       protected:
 
 #if !GTKMM_CHECK_VERSION(2,5,0)
-        virtual void on_spinbutton_digits_changed(){
+        void on_spinbutton_digits_changed() override
+        {
             const size_t size = 256;
             char str[ size ];
             snprintf( str, size, "%d", (int)get_value() );
@@ -43,7 +44,8 @@ namespace SKELETON
       protected:
 
 #if !GTKMM_CHECK_VERSION(2,5,0)
-        virtual void on_spinbutton_digits_changed(){
+        void on_spinbutton_digits_changed() override
+        {
             const size_t size = 256;
             char str[ size ];
             snprintf( str, size, "%4.3lf", get_value() );

--- a/src/skeleton/tablabel.h
+++ b/src/skeleton/tablabel.h
@@ -46,7 +46,7 @@ namespace SKELETON
       public:
 
         TabLabel( const std::string& url );
-        virtual ~TabLabel();
+        ~TabLabel();
 
         SIG_TAB_MOTION_EVENT sig_tab_motion_event(){ return  m_sig_tab_motion_event; }
         SIG_TAB_LEAVE_EVENT sig_tab_leave_event(){ return m_sig_tab_leave_event; }
@@ -88,13 +88,13 @@ namespace SKELETON
 
       private:
 
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
-        virtual bool on_leave_notify_event( GdkEventCrossing* event );
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
+        bool on_leave_notify_event( GdkEventCrossing* event ) override;
 
-        virtual void on_drag_begin( const Glib::RefPtr< Gdk::DragContext>& context );
-        virtual void on_drag_data_get( const Glib::RefPtr<Gdk::DragContext>& context,
-                                       Gtk::SelectionData& selection_data, guint info, guint time );
-        virtual void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context );
+        void on_drag_begin( const Glib::RefPtr< Gdk::DragContext >& context ) override;
+        void on_drag_data_get( const Glib::RefPtr< Gdk::DragContext >& context,
+                               Gtk::SelectionData& selection_data, guint info, guint time ) override;
+        void on_drag_end( const Glib::RefPtr< Gdk::DragContext>& context ) override;
     }; 
 }
 

--- a/src/skeleton/tabnote.cpp
+++ b/src/skeleton/tabnote.cpp
@@ -340,7 +340,7 @@ public:
         set_flags( Gtk::NO_WINDOW );
 #endif
     }
-    virtual ~DummyWidget(){}
+    ~DummyWidget() noexcept {}
 };
 
 

--- a/src/skeleton/tabnote.h
+++ b/src/skeleton/tabnote.h
@@ -122,19 +122,19 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
-        virtual void on_size_allocate( Gtk::Allocation& allocation );
+        bool on_expose_event( GdkEventExpose* event ) override;
+        void on_size_allocate( Gtk::Allocation& allocation ) override;
 
         // signal_button_press_event と signal_button_release_event は emit されない
         // ときがあるので自前でemitする
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
 
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
-        virtual bool on_leave_notify_event( GdkEventCrossing* event );
-        virtual bool on_scroll_event( GdkEventScroll* event );
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
+        bool on_leave_notify_event( GdkEventCrossing* event ) override;
+        bool on_scroll_event( GdkEventScroll* event ) override;
 
-        virtual bool on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time);
+        bool on_drag_motion( const Glib::RefPtr<Gdk::DragContext>& context, int x, int y, guint time) override;
     };
 }
 

--- a/src/skeleton/tabswitchbutton.cpp
+++ b/src/skeleton/tabswitchbutton.cpp
@@ -33,7 +33,7 @@ TabSwitchButton::TabSwitchButton( DragableNoteBook* parent )
 }
 
 
-TabSwitchButton::~TabSwitchButton()
+TabSwitchButton::~TabSwitchButton() noexcept
 {}
 
 

--- a/src/skeleton/tabswitchbutton.h
+++ b/src/skeleton/tabswitchbutton.h
@@ -29,7 +29,7 @@ namespace SKELETON
       public:
 
         TabSwitchButton( DragableNoteBook* parent );
-        virtual ~TabSwitchButton();
+        ~TabSwitchButton() noexcept;
 
         Gtk::Button& get_button(){ return m_button; }
         void show_button();
@@ -37,7 +37,7 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
     };
 }
 

--- a/src/skeleton/tabswitchmenu.h
+++ b/src/skeleton/tabswitchmenu.h
@@ -26,7 +26,7 @@ namespace SKELETON
       public:
 
         TabSwitchMenu( DragableNoteBook* notebook, Admin* admin );
-        virtual ~TabSwitchMenu();
+        ~TabSwitchMenu();
 
         void remove_items();
         void append_items();
@@ -38,7 +38,7 @@ namespace SKELETON
 
       protected:
 
-        virtual void on_deactivate();
+        void on_deactivate() override;
 
     };
 }

--- a/src/skeleton/textloader.h
+++ b/src/skeleton/textloader.h
@@ -62,8 +62,8 @@ namespace SKELETON
         void init();
         void clear();
 
-        virtual void receive_data( const char* data, size_t size );
-        virtual void receive_finish();
+        void receive_data( const char* data, size_t size ) override;
+        void receive_finish() override;
     };
 }
 

--- a/src/skeleton/toolbar.h
+++ b/src/skeleton/toolbar.h
@@ -78,7 +78,7 @@ namespace SKELETON
       public:
 
         ToolBar( Admin* admin );
-        virtual ~ToolBar(){}
+        ~ToolBar() noexcept {}
 
         void set_url( const std::string& url );
         const std::string& get_url() { return m_url; }

--- a/src/skeleton/toolbarnote.h
+++ b/src/skeleton/toolbarnote.h
@@ -22,7 +22,7 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
     };
 }
 

--- a/src/skeleton/treeviewbase.cpp
+++ b/src/skeleton/treeviewbase.cpp
@@ -19,7 +19,7 @@ JDTreeViewBase::JDTreeViewBase()
 }
 
 
-JDTreeViewBase::~JDTreeViewBase()
+JDTreeViewBase::~JDTreeViewBase() noexcept
 {}
 
 

--- a/src/skeleton/treeviewbase.h
+++ b/src/skeleton/treeviewbase.h
@@ -43,7 +43,7 @@ namespace SKELETON
         SIG_MOTION_NOTIFY& sig_motion_notify() { return m_sig_motion_notify; }
 
         JDTreeViewBase();
-        virtual ~JDTreeViewBase();
+        ~JDTreeViewBase() noexcept;
 
         // 行数
         const int get_row_size();
@@ -99,13 +99,13 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_key_press_event( GdkEventKey* event );
-        virtual bool on_key_release_event( GdkEventKey* event );
+        bool on_key_press_event( GdkEventKey* event ) override;
+        bool on_key_release_event( GdkEventKey* event ) override;
 
-        virtual bool on_scroll_event( GdkEventScroll* event );
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
+        bool on_scroll_event( GdkEventScroll* event ) override;
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
    };
 }
 

--- a/src/skeleton/undobuffer.h
+++ b/src/skeleton/undobuffer.h
@@ -56,7 +56,7 @@ namespace SKELETON
       public:
 
         UNDO_BUFFER();
-        virtual ~UNDO_BUFFER(){}
+        virtual ~UNDO_BUFFER() noexcept {}
 
         SIG_UNDO sig_undo(){ return m_sig_undo; }
         SIG_REDO sig_redo(){ return m_sig_redo; }

--- a/src/skeleton/view.h
+++ b/src/skeleton/view.h
@@ -164,7 +164,7 @@ namespace SKELETON
         SIG_RESIZE_POPUP sig_resize_popup(){ return m_sig_resize_popup; }
         
         View( const std::string& url, const std::string& arg1 = std::string(), const std::string& arg2 = std::string() );
-        virtual ~View(){}
+        ~View() noexcept {}
 
         virtual void save_session() = 0;
 

--- a/src/skeleton/viewnote.h
+++ b/src/skeleton/viewnote.h
@@ -24,7 +24,7 @@ namespace SKELETON
 
       protected:
 
-        virtual bool on_expose_event( GdkEventExpose* event );
+        bool on_expose_event( GdkEventExpose* event ) override;
     };
 }
 

--- a/src/skeleton/vpaned.h
+++ b/src/skeleton/vpaned.h
@@ -19,18 +19,18 @@ namespace SKELETON
       public:
 
         JDVPaned( const int fixmode );
-        virtual ~JDVPaned(){}
+        ~JDVPaned() noexcept {}
 
         VPaneControl& get_ctrl(){ return m_pctrl; }
 
       protected:
 
-        virtual void on_realize();
-        virtual bool on_button_press_event( GdkEventButton* event );
-        virtual bool on_button_release_event( GdkEventButton* event );
-        virtual bool on_motion_notify_event( GdkEventMotion* event );
-        virtual bool on_enter_notify_event( GdkEventCrossing* event );
-        virtual bool on_leave_notify_event( GdkEventCrossing* event );
+        void on_realize() override;
+        bool on_button_press_event( GdkEventButton* event ) override;
+        bool on_button_release_event( GdkEventButton* event ) override;
+        bool on_motion_notify_event( GdkEventMotion* event ) override;
+        bool on_enter_notify_event( GdkEventCrossing* event ) override;
+        bool on_leave_notify_event( GdkEventCrossing* event ) override;
     };
 }
 

--- a/src/skeleton/window.h
+++ b/src/skeleton/window.h
@@ -56,7 +56,7 @@ namespace SKELETON
       public:
 
         JDWindow( const bool fold_when_focusout, const bool need_mginfo = true );
-        virtual ~JDWindow();
+        ~JDWindow();
 
         Gtk::HBox& get_statbar(){ return  m_statbar; }
 
@@ -130,12 +130,12 @@ namespace SKELETON
         virtual const bool is_shown_win() = 0;
         virtual void set_shown_win( const bool set ) = 0;
 
-        virtual bool on_focus_in_event( GdkEventFocus* event );
-        virtual bool on_focus_out_event( GdkEventFocus* event );
-        virtual bool on_delete_event( GdkEventAny* event );
-        virtual bool on_window_state_event( GdkEventWindowState* event );
-        virtual bool on_configure_event( GdkEventConfigure* event );
-        virtual bool on_key_press_event( GdkEventKey* event );
+        bool on_focus_in_event( GdkEventFocus* event ) override;
+        bool on_focus_out_event( GdkEventFocus* event ) override;
+        bool on_delete_event( GdkEventAny* event ) override;
+        bool on_window_state_event( GdkEventWindowState* event ) override;
+        bool on_configure_event( GdkEventConfigure* event ) override;
+        bool on_key_press_event( GdkEventKey* event ) override;
 
       private:
 

--- a/src/sound/playsound.h
+++ b/src/sound/playsound.h
@@ -56,7 +56,7 @@ namespace SOUND
       public:
 
         Play_Sound();
-        virtual ~Play_Sound();
+        ~Play_Sound();
 
         const bool is_playing() const { return m_playing; }
 
@@ -68,7 +68,7 @@ namespace SOUND
         void wait();
         static void* launcher( void* );
         void play_wavfile();
-        virtual void callback_dispatch();
+        void callback_dispatch() override;
 
     };
 

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -44,7 +44,7 @@ CheckUpdate_Manager::CheckUpdate_Manager()
 }
 
 
-CheckUpdate_Manager::~CheckUpdate_Manager()
+CheckUpdate_Manager::~CheckUpdate_Manager() noexcept
 {
     assert( ! m_list_item.size() );
 }

--- a/src/updatemanager.h
+++ b/src/updatemanager.h
@@ -37,7 +37,7 @@ namespace CORE
       public:
 
         CheckUpdate_Manager();
-        virtual ~CheckUpdate_Manager();
+        virtual ~CheckUpdate_Manager() noexcept;
 
         void run();
         void stop();

--- a/src/urlreplacemanager.h
+++ b/src/urlreplacemanager.h
@@ -39,7 +39,7 @@ namespace CORE
       public:
 
         Urlreplace_Manager();
-        virtual ~Urlreplace_Manager(){}
+        virtual ~Urlreplace_Manager() noexcept {}
 
         // URLを任意の正規表現で変換する
         const bool exec( std::string &url );

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -27,7 +27,7 @@ namespace CORE
     public:
 
         Usrcmd_Manager();
-        virtual ~Usrcmd_Manager(){}
+        virtual ~Usrcmd_Manager() noexcept {}
 
         XML::Document& xml_document() { return m_document; }
         void analyze_xml();

--- a/src/usrcmdpref.h
+++ b/src/usrcmdpref.h
@@ -61,10 +61,10 @@ namespace CORE
 
       private:
 
-        virtual void timeout();
+        void timeout() override;
 
         // OK押した
-        virtual void slot_ok_clicked();
+        void slot_ok_clicked() override;
 
         bool slot_button_press( GdkEventButton* event );
         bool slot_button_release( GdkEventButton* event );

--- a/src/winmain.h
+++ b/src/winmain.h
@@ -26,7 +26,7 @@ class JDWinMain : public SKELETON::JDWindow
   public:
 
     JDWinMain( const bool init, const bool skip_setupdiag, const int init_w, const int init_h, const int init_x, const int init_y );
-    virtual ~JDWinMain();
+    ~JDWinMain();
 
     // 通常のセッション保存
     void save_session();
@@ -35,37 +35,37 @@ class JDWinMain : public SKELETON::JDWindow
 
   protected:
 
-    virtual const int get_x_win();
-    virtual const int get_y_win();
-    virtual void set_x_win( const int x );
-    virtual void set_y_win( const int y );
+    const int get_x_win() override;
+    const int get_y_win() override;
+    void set_x_win( const int x ) override;
+    void set_y_win( const int y ) override;
 
-    virtual const int get_width_win();
-    virtual const int get_height_win();
-    virtual void set_width_win( const int width );
-    virtual void set_height_win( const int height );
+    const int get_width_win() override;
+    const int get_height_win() override;
+    void set_width_win( const int width ) override;
+    void set_height_win( const int height ) override;
 
-    virtual const bool is_focus_win();
-    virtual void set_focus_win( const bool set );
+    const bool is_focus_win() override;
+    void set_focus_win( const bool set ) override;
 
-    virtual const bool is_maximized_win();
-    virtual void set_maximized_win( const bool set );
+    const bool is_maximized_win() override;
+    void set_maximized_win( const bool set ) override;
 
-    virtual const bool is_iconified_win();
-    virtual void set_iconified_win( const bool set );
+    const bool is_iconified_win() override;
+    void set_iconified_win( const bool set ) override;
 
-    virtual const bool is_full_win();
-    virtual void set_full_win( const bool set );
+    const bool is_full_win() override;
+    void set_full_win( const bool set ) override;
 
-    virtual const bool is_shown_win();
-    virtual void set_shown_win( const bool set );
+    const bool is_shown_win() override;
+    void set_shown_win( const bool set ) override;
 
-    virtual bool on_delete_event( GdkEventAny* event );
-    virtual bool on_window_state_event( GdkEventWindowState* event );
-    virtual bool on_configure_event( GdkEventConfigure* event );
-    virtual bool on_button_press_event( GdkEventButton* event );
-    virtual bool on_button_release_event( GdkEventButton* event );
-    virtual bool on_motion_notify_event( GdkEventMotion* event );
+    bool on_delete_event( GdkEventAny* event ) override;
+    bool on_window_state_event( GdkEventWindowState* event ) override;
+    bool on_configure_event( GdkEventConfigure* event ) override;
+    bool on_button_press_event( GdkEventButton* event ) override;
+    bool on_button_release_event( GdkEventButton* event ) override;
+    bool on_motion_notify_event( GdkEventMotion* event ) override;
 
   private:
     const bool operate_win( const int control );

--- a/src/xml/document.h
+++ b/src/xml/document.h
@@ -30,7 +30,7 @@ namespace XML
         // 何も無い状態からノードツリーを作る場合
         Document();
 
-        virtual ~Document(){};
+        ~Document() noexcept {}
 
         // このクラスは代入可能
         Document& operator=( const Document& document );


### PR DESCRIPTION
`override`キーワードを使ってオーバーライドされた仮想関数をマークし`virtual`を外します。これにより仮想関数の作成`virtual`とオーバーライド`override`を区別することができます。
修正した行数が多いので後続の修正(`-Wextra`とgtk3サポート)は様子を見て提出します。